### PR TITLE
Code-style changes and Zebra compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.DS_Store
+/packages
+/.theos

--- a/BMHomeTableViewController.xm
+++ b/BMHomeTableViewController.xm
@@ -204,7 +204,7 @@
         typeOfDebMsg = @"Creating your offline .deb....\n";
     }
     
-    NSString *motherMessage = [bm showProcessingDialog:typeOfDebMsg includeStage:true startingStep:1 autoPresent:false];
+    NSString *motherMessage = [bm showProcessingDialog:typeOfDebMsg includeStage:YES startingStep:1 autoPresent:NO];
     [self presentViewController:bm.processingDialog animated:YES completion:^{
         [bm createDeb:type withMotherMessage:motherMessage];
     }];
@@ -252,7 +252,7 @@
     
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Batchomatic" message:infoMsg preferredStyle:UIAlertControllerStyleAlert];
     UIAlertAction *proceedAction = [UIAlertAction actionWithTitle:@"Proceed" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-        [bm showProcessingDialog:processingMsg includeStage:true startingStep:1 autoPresent:false];
+        [bm showProcessingDialog:processingMsg includeStage:YES startingStep:1 autoPresent:NO];
         [bm.bm_BMHomeTableViewController presentViewController:bm.processingDialog animated:YES completion:^{
             if (type == 1) {
                 [bm removeAllRepos];
@@ -271,7 +271,7 @@
 }
 
 - (void)didTapRespringButton {
-    [[Batchomatic sharedInstance] endProcessingDialog:nil transition:false shouldOpenBMHomeViewControllerFirst:false];
+    [[Batchomatic sharedInstance] endProcessingDialog:nil transition:NO shouldOpenBMHomeViewControllerFirst:NO];
 }
 
 - (void)didTapBackButton {

--- a/BMHomeTableViewController.xm
+++ b/BMHomeTableViewController.xm
@@ -3,7 +3,7 @@
 #import "Headers/BMInstallTableViewController.h"
 #import "Headers/BMRepackTableViewController.h"
 
-@implementation BMHomeTableViewController //The main Batchomatic screen where you choose what feature to use
+@implementation BMHomeTableViewController // The main Batchomatic screen where you choose what feature to use
 - (NSString *)versionNumber {
     return @"v4.3.1";
 }
@@ -13,7 +13,8 @@
     Batchomatic *bm = [Batchomatic sharedInstance];
     bm.bm_BMHomeTableViewController = self;
     
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void) { //must use dispatch_async to prevent the UI from freezing
+    // must use dispatch_async to prevent the UI from freezing
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void) {
         [bm determineInfoAboutDeb];
         [bm loadListOfCurrentlyInstalledTweaks];
     });
@@ -24,19 +25,23 @@
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    [Batchomatic sharedInstance].bm_currentBMController = self; //this variable is whatever Batchomatic view controller is currently on-screen
-    [self addVersionNumberFooter]; //when this was in viewDidLoad, the version number wasn't being centered on iPads, but putting this in viewWillAppear fixed it
+    // this variable is whatever Batchomatic view controller is currently on-screen
+    [Batchomatic sharedInstance].bm_currentBMController = self;
+    // when this was in viewDidLoad, the version number wasn't being centered on iPads, but putting this in viewWillAppear fixed it
+    [self addVersionNumberFooter];
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-- (void)createNavBar { //Creates the main navigation bar with a custom icon next to the large title
+// Creates the main navigation bar with a custom icon next to the large title
+- (void)createNavBar {
     self.navigationItem.title = @"Batchomatic";
     UINavigationBar *navBar = self.navigationController.navigationBar;
     navBar.prefersLargeTitles = YES;
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Back" style:UIBarButtonItemStylePlain target:self action:@selector(didTapBackButton)];
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Help" style:UIBarButtonItemStylePlain target:self action:@selector(didTapHelpButton)];
     
-    NSBundle *bundle = [NSBundle bundleWithPath:@"/Library/Batchomatic/Icon.bundle"]; //custom view in UINavigationBarLargeTitleView for the icon
+    // custom view in UINavigationBarLargeTitleView for the icon
+    NSBundle *bundle = [NSBundle bundleWithPath:@"/Library/Batchomatic/Icon.bundle"];
     UIImage *icon = [[UIImage imageNamed:@"Icon" inBundle:bundle compatibleWithTraitCollection:nil] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     UIImageView *imgView = [[UIImageView alloc] initWithImage:icon];
     
@@ -66,13 +71,16 @@
     self.tableView = tableView;
 }
 
-- (void)addVersionNumberFooter { //Add the version number as footer of the UITableView
+// Add the version number as footer of the UITableView
+- (void)addVersionNumberFooter {
     Batchomatic *bm = [Batchomatic sharedInstance];
     UIView *footer = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.tableView.frame.size.width, 28)];
     UILabel *label = [[UILabel alloc] initWithFrame:footer.frame];
     label.text = [self versionNumber];
     label.textAlignment = NSTextAlignmentCenter;
-    if (bm.packageManager == 2 && [%c(ZBDevice) darkModeEnabled]) { //Zebra has its own dark mode that doesn't follow the iOS 13 dark mode, so we need to manually set the text color when in Zebra's dark mode
+    // Zebra has its own dark mode that doesn't follow the iOS 13 dark
+    // mode, so we need to manually set the text color when in Zebra's dark mode
+    if (bm.packageManager == 2 && [%c(ZBDevice) darkModeEnabled]) {
         label.textColor = [UIColor whiteColor];
     }
     [footer addSubview:label];
@@ -96,11 +104,14 @@
     }
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section { //Add section separators and hide the cell separator lines of extraneous/unused cells
+// Add section separators and hide the cell separator lines of extraneous/unused cells
+- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section {
     return [[UIView alloc] init];
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section { //Make the version number at the bottom appear close to my UITableView instead of floating in the middle of nowhere
+// Make the version number at the bottom appear close to my UITableView
+// instead of floating in the middle of nowhere
+- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section {
     if (section == 2) {
         return 7;
     }
@@ -124,25 +135,30 @@
         cell.textLabel.textColor = [UIColor whiteColor];
     }
     
-    if (indexPath.section == 0) { //top section
+    // top section
+    if (indexPath.section == 0) {
         NSArray *cellTitles = @[@"Create online .deb", @"Create offline .deb", @"Install .deb"];
         cell.textLabel.text = [cellTitles objectAtIndex:indexPath.row];
     }
-    else if (indexPath.section == 1) { //middle section
+    // middle section
+    else if (indexPath.section == 1) {
         NSArray *cellTitles = @[@"Repack tweak to .deb", @"Remove all repos", @"Remove all tweaks"];
         cell.textLabel.text = [cellTitles objectAtIndex:indexPath.row];
     }
-    else { //bottom section
+    // bottom section
+    else {
         cell.textLabel.text = @"Respring";
     }
     
-    cell.selectionStyle = UITableViewCellSelectionStyleDefault; //adds the select-then-immediately-deselect animation when tapping on a row
+    // adds the select-then-immediately-deselect animation when tapping on a row
+    cell.selectionStyle = UITableViewCellSelectionStyleDefault;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     return cell;
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    [tableView deselectRowAtIndexPath:indexPath animated:YES]; //this is also needed for that select-then-immediately-deselect animation
+    // this is also needed for that select-then-immediately-deselect animation
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
     if (indexPath.section == 0) {
         if (indexPath.row == 0) {
             [self didTapEitherCreateDebButton:1];
@@ -173,14 +189,17 @@
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-- (void)didTapEitherCreateDebButton:(int)type { //Does some prep work before actually creating the .deb
+// Does some prep work before actually creating the .deb
+- (void)didTapEitherCreateDebButton:(int)type {
     Batchomatic *bm = [Batchomatic sharedInstance];
     NSString *typeOfDebMsg;
-    if (type == 1) { //type 1 means an online .deb
+    // type 1 means an online .deb
+    if (type == 1) {
         bm.maxSteps = 1;
         typeOfDebMsg = @"Creating your online .deb....\n";
     }
-    else { //type 2 means an offline .deb
+    // type 2 means an offline .deb
+    else {
         bm.maxSteps = 3;
         typeOfDebMsg = @"Creating your offline .deb....\n";
     }
@@ -191,7 +210,9 @@
     }];
 }
 
-- (void)didTapInstallDebButton { //Shows the Install options screen (BMInstallTableViewController) if your .deb is currently installed
+// Shows the Install options screen (BMInstallTableViewController)
+// if your .deb is currently installed
+- (void)didTapInstallDebButton {
     Batchomatic *bm = [Batchomatic sharedInstance];
     if (bm.debIsInstalled) {
         UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:[[BMInstallTableViewController alloc] init]];
@@ -210,17 +231,21 @@
     [self presentViewController:nav animated:YES completion:nil];
 }
 
-- (void)didTapEitherRemoveAllButton:(int)type { //Asks the user if they want to keep utiity repos and BigBoss when removing all repos. Also handles asking to keep package managers, Filza, and Batchomatic itself when removing all tweaks
+// Asks the user if they want to keep utiity repos and
+// BigBoss when removing all repos. Also handles asking to keep package managers, Filza, and Batchomatic itself when removing all tweaks
+- (void)didTapEitherRemoveAllButton:(int)type {
     Batchomatic *bm = [Batchomatic sharedInstance];
     bm.maxSteps = 1;
     
     NSString *infoMsg;
     NSString *processingMsg;
-    if (type == 1) { //type 1 means remove all repos
+    // type 1 means remove all repos
+    if (type == 1) {
         infoMsg = @"When OFF, utility repos and BigBoss will stay";
         processingMsg = @"Removing repos....";
     }
-    else { //type 2 means remove all tweaks
+    // type 2 means remove all tweaks
+    else {
         infoMsg = @"When OFF, Zebra/Installer/Filza/Batchomatic will stay";
         processingMsg = @"Removing tweaks....";
     }

--- a/BMHomeTableViewController.xm
+++ b/BMHomeTableViewController.xm
@@ -1,3 +1,11 @@
+//
+//  BMHomeTableViewController.m
+//  Batchomatic
+//  
+//  Created by Capt Inc on 2020-06-01
+//  Copyright © 2020 Capt Inc. All rights reserved.
+//
+
 #import "Headers/Batchomatic.h"
 #import "Headers/BMHomeTableViewController.h"
 #import "Headers/BMInstallTableViewController.h"

--- a/BMHomeTableViewController.xm
+++ b/BMHomeTableViewController.xm
@@ -22,9 +22,14 @@
     bm.bm_BMHomeTableViewController = self;
     
     // must use dispatch_async to prevent the UI from freezing
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void) {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [bm determineInfoAboutDeb];
-        [bm loadListOfCurrentlyInstalledTweaks];
+        if (![bm loadListOfCurrentlyInstalledTweaks]) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                NSString *message = @"Could not list installed tweaks. Try running ldid -S /usr/bin/bmd";
+                [self showAlert:@"Error" message:message];
+            });
+        }
     });
     
     [self createNavBar];
@@ -37,6 +42,17 @@
     [Batchomatic sharedInstance].bm_currentBMController = self;
     // when this was in viewDidLoad, the version number wasn't being centered on iPads, but putting this in viewWillAppear fixed it
     [self addVersionNumberFooter];
+}
+
+- (void)showAlert:(NSString *)title message:(NSString *)message {
+    UIAlertController *alert = [UIAlertController
+        alertControllerWithTitle:title
+        message:message
+        preferredStyle:UIAlertControllerStyleAlert
+    ];
+
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
 }
 
 //--------------------------------------------------------------------------------------------------------------------------

--- a/BMInstallTableViewController.xm
+++ b/BMInstallTableViewController.xm
@@ -1,7 +1,7 @@
 #import "Headers/Batchomatic.h"
 #import "Headers/BMInstallTableViewController.h"
 
-@implementation BMInstallTableViewController //The installation options screen
+@implementation BMInstallTableViewController // The installation options screen
 - (void)viewDidLoad {
     [super viewDidLoad];
     Batchomatic *bm = [Batchomatic sharedInstance];
@@ -40,7 +40,8 @@
     }
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section { //Hide the cell separator lines of extraneous/unused cells
+// Hide the cell separator lines of extraneous/unused cells
+- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section {
     return [[UIView alloc] init];
 }
 
@@ -58,7 +59,8 @@
         cell.textLabel.textColor = [UIColor whiteColor];
     }
     
-    if (indexPath.section == 0) { //put a UISwitch in each row of the top section
+    // put a UISwitch in each row of the top section
+    if (indexPath.section == 0) {
         NSArray *cellTitles = @[@"Install preferences", @"Install hosts file", @"Install saved .debs", @"Add repos", @"Queue tweaks", @"Install offline tweaks"];
         cell.textLabel.text = [cellTitles objectAtIndex:indexPath.row];
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
@@ -70,21 +72,26 @@
         bm.hostsSwitchStatus = true;
         bm.savedDebsSwitchStatus = true;
         
-        if (bm.debIsOnline) { //if the .deb is online mode, the offline switch gets greyed out
+        // if the .deb is online mode, the offline switch gets greyed out
+        if (bm.debIsOnline) {
             if (indexPath.row == 3 || indexPath.row == 4) {
                 [toggle setOn:YES animated:YES];
                 bm.reposSwitchStatus = true;
                 bm.tweaksSwitchStatus = true;
             }
             if (indexPath.row == 5) {
-                [toggle setOn:NO animated:YES]; //turn the switch off
+                // turn the switch off
+                [toggle setOn:NO animated:YES];
                 bm.offlineTweaksSwitchStatus = false;
-                toggle.enabled = NO; //grey out the switch
-                cell.textLabel.alpha = 0.439216f; //grey out the label
+                // grey out the switch
+                toggle.enabled = NO;
+                // grey out the label
+                cell.textLabel.alpha = 0.439216f;
                 cell.userInteractionEnabled = NO;
             }
         }
-        else { //and vice versa if the .deb is offline mode
+        // and vice versa if the .deb is offline mode
+        else {
             if (indexPath.row == 3 || indexPath.row == 4) {
                 [toggle setOn:NO animated:YES];
                 bm.reposSwitchStatus = false;
@@ -102,7 +109,8 @@
         [toggle addTarget:bm action:@selector(toggleTapped:) forControlEvents:UIControlEventValueChanged]; //"- (void)toggleTapped:" will update the corresponding boolean variable whenever the switch is tapped
         cell.accessoryView = toggle;
     }
-    else { //customizes the "Proceed" button/row
+    // customizes the "Proceed" button/row
+    else {
         NSArray *cellTitles = @[@"Proceed"];
         cell.textLabel.text = [cellTitles objectAtIndex:indexPath.row];
         if (indexPath.row == 0) {
@@ -126,7 +134,8 @@
 //--------------------------------------------------------------------------------------------------------------------------
 - (void)didTapProceedButton {
     Batchomatic *bm = [Batchomatic sharedInstance];
-    [bm calculateMaxStepsForInstalling]; //must do some prep work before actually installing the .deb
+    // must do some prep work before actually installing the .deb
+    [bm calculateMaxStepsForInstalling];
     [bm showProcessingDialog:@"Preparing...." includeStage:true startingStep:0 autoPresent:false];
     [self presentViewController:bm.processingDialog animated:YES completion:^{
         [bm installDeb];

--- a/BMInstallTableViewController.xm
+++ b/BMInstallTableViewController.xm
@@ -68,21 +68,21 @@
         UISwitch *toggle = [[UISwitch alloc] initWithFrame:CGRectZero];
         toggle.tag = indexPath.row;
         [toggle setOn:YES animated:YES];
-        bm.prefsSwitchStatus = true;
-        bm.hostsSwitchStatus = true;
-        bm.savedDebsSwitchStatus = true;
+        bm.prefsSwitchStatus = YES;
+        bm.hostsSwitchStatus = YES;
+        bm.savedDebsSwitchStatus = YES;
         
         // if the .deb is online mode, the offline switch gets greyed out
         if (bm.debIsOnline) {
             if (indexPath.row == 3 || indexPath.row == 4) {
                 [toggle setOn:YES animated:YES];
-                bm.reposSwitchStatus = true;
-                bm.tweaksSwitchStatus = true;
+                bm.reposSwitchStatus = YES;
+                bm.tweaksSwitchStatus = YES;
             }
             if (indexPath.row == 5) {
                 // turn the switch off
                 [toggle setOn:NO animated:YES];
-                bm.offlineTweaksSwitchStatus = false;
+                bm.offlineTweaksSwitchStatus = NO;
                 // grey out the switch
                 toggle.enabled = NO;
                 // grey out the label
@@ -94,15 +94,15 @@
         else {
             if (indexPath.row == 3 || indexPath.row == 4) {
                 [toggle setOn:NO animated:YES];
-                bm.reposSwitchStatus = false;
-                bm.tweaksSwitchStatus = false;
+                bm.reposSwitchStatus = NO;
+                bm.tweaksSwitchStatus = NO;
                 toggle.enabled = NO;
                 cell.textLabel.alpha = 0.439216f;
                 cell.userInteractionEnabled = NO;
             }
             if (indexPath.row == 5) {
                 [toggle setOn:YES animated:YES];
-                bm.offlineTweaksSwitchStatus = true;
+                bm.offlineTweaksSwitchStatus = YES;
             }
         }
         
@@ -136,7 +136,7 @@
     Batchomatic *bm = [Batchomatic sharedInstance];
     // must do some prep work before actually installing the .deb
     [bm calculateMaxStepsForInstalling];
-    [bm showProcessingDialog:@"Preparing...." includeStage:true startingStep:0 autoPresent:false];
+    [bm showProcessingDialog:@"Preparing...." includeStage:YES startingStep:0 autoPresent:NO];
     [self presentViewController:bm.processingDialog animated:YES completion:^{
         [bm installDeb];
     }];

--- a/BMInstallTableViewController.xm
+++ b/BMInstallTableViewController.xm
@@ -1,3 +1,11 @@
+//
+//  BMInstallTableViewController.m
+//  Batchomatic
+//  
+//  Created by Capt Inc on 2020-06-01
+//  Copyright © 2020 Capt Inc. All rights reserved.
+//
+
 #import "Headers/Batchomatic.h"
 #import "Headers/BMInstallTableViewController.h"
 

--- a/BMInstallTableViewController.xm
+++ b/BMInstallTableViewController.xm
@@ -106,7 +106,7 @@
             }
         }
         
-        [toggle addTarget:bm action:@selector(toggleTapped:) forControlEvents:UIControlEventValueChanged]; //"- (void)toggleTapped:" will update the corresponding boolean variable whenever the switch is tapped
+        [toggle addTarget:bm action:@selector(toggleTapped:) forControlEvents:UIControlEventValueChanged]; //"- (void)toggleTapped:" will update the corresponding BOOLean variable whenever the switch is tapped
         cell.accessoryView = toggle;
     }
     // customizes the "Proceed" button/row

--- a/BMRepackTableViewController.xm
+++ b/BMRepackTableViewController.xm
@@ -105,7 +105,7 @@
     Batchomatic *bm = [Batchomatic sharedInstance];
     bm.maxSteps = 1;
     NSString *msg = [NSString stringWithFormat:@"Repacking tweak to .deb....\n%@", packageID];
-    [bm showProcessingDialog:msg includeStage:true startingStep:1 autoPresent:false];
+    [bm showProcessingDialog:msg includeStage:YES startingStep:1 autoPresent:NO];
     [self presentViewController:bm.processingDialog animated:YES completion:^{
         [bm repackTweakWithIdentifier:packageID];
     }];

--- a/BMRepackTableViewController.xm
+++ b/BMRepackTableViewController.xm
@@ -1,7 +1,7 @@
 #import "Headers/Batchomatic.h"
 #import "Headers/BMRepackTableViewController.h"
 
-@implementation BMRepackTableViewController //The Repack deb screen
+@implementation BMRepackTableViewController // The Repack deb screen
 - (void)viewDidLoad {
     [super viewDidLoad];
     Batchomatic *bm = [Batchomatic sharedInstance];
@@ -35,7 +35,8 @@
         spinner.color = [UIColor colorWithRed:0.557 green:0.557 blue:0.576 alpha:1];
     }
     
-    spinner.autoresizingMask = (UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin); //center the UIActivityIndicator
+    // center the UIActivityIndicator
+    spinner.autoresizingMask = (UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin);
     CGFloat height = (CGRectGetHeight(self.view.bounds) / 2) - self.navigationController.navigationBar.frame.size.height;
     spinner.center = CGPointMake(CGRectGetWidth(self.view.bounds) / 2, height);
     
@@ -59,7 +60,8 @@
     return [[Batchomatic sharedInstance].currentlyInstalledTweaks count];
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section { //Hide the cell separator lines of extraneous/unused cells
+// Hide the cell separator lines of extraneous/unused cells
+- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section {
     return [[UIView alloc] init];
 }
 
@@ -67,7 +69,9 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     static NSString *cellIdentifier = @"Cell";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:cellIdentifier forIndexPath:indexPath];
-    if (!cell || !cell.detailTextLabel) { //in order to make detailTextLabel work, you must check if cell is nil or if cell.detailTextLabel is nil
+    // in order to make detailTextLabel work, you must check if cell is nil or
+    // if cell.detailTextLabel is nil
+    if (!cell || !cell.detailTextLabel) {
         cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:cellIdentifier];
     }
     Batchomatic *bm = [Batchomatic sharedInstance];
@@ -75,7 +79,8 @@
     
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     cell.detailTextLabel.font = [UIFont systemFontOfSize:12];
-    cell.detailTextLabel.textColor = [UIColor systemGrayColor]; //make the package ID text a light gray
+    // make the package ID text a light gray
+    cell.detailTextLabel.textColor = [UIColor systemGrayColor];
     if (bm.packageManager == 2 && [%c(ZBDevice) darkModeEnabled]) {
         cell.textLabel.textColor = [UIColor whiteColor];
         cell.detailTextLabel.textColor = [UIColor colorWithRed:0.557 green:0.557 blue:0.576 alpha:1];

--- a/BMRepackTableViewController.xm
+++ b/BMRepackTableViewController.xm
@@ -1,3 +1,11 @@
+//
+//  BMRepackTableViewController.m
+//  Batchomatic
+//  
+//  Created by Capt Inc on 2020-06-01
+//  Copyright © 2020 Capt Inc. All rights reserved.
+//
+
 #import "Headers/Batchomatic.h"
 #import "Headers/BMRepackTableViewController.h"
 

--- a/Batchomatic.xm
+++ b/Batchomatic.xm
@@ -125,25 +125,25 @@ int refreshesCompleted = 0;
 // user turned on. This method is only called when installing a .deb
 - (void)calculateMaxStepsForInstalling {
     self.maxSteps = 0;
-    if (self.prefsSwitchStatus == true) {
+    if (self.prefsSwitchStatus) {
         self.maxSteps++;
     }
-    if (self.savedDebsSwitchStatus == true) {
+    if (self.savedDebsSwitchStatus) {
         self.maxSteps++;
     }
-    if (self.hostsSwitchStatus == true) {
+    if (self.hostsSwitchStatus) {
         self.maxSteps++;
     }
     if (self.debIsOnline) {
-        if (self.reposSwitchStatus == true) {
+        if (self.reposSwitchStatus) {
             self.maxSteps++;
         }
-        if (self.tweaksSwitchStatus == true) {
+        if (self.tweaksSwitchStatus) {
             self.maxSteps++;
         }
     }
     else {
-        if (self.offlineTweaksSwitchStatus == true) {
+        if (self.offlineTweaksSwitchStatus) {
             self.maxSteps++;
         }
     }
@@ -153,31 +153,31 @@ int refreshesCompleted = 0;
 // A few other methods need to be called before calling this one.
 // See BMInstallTableViewController.xm for more info
 - (void)installDeb {
-    if (self.prefsSwitchStatus == true) {
+    if (self.prefsSwitchStatus) {
         [self updateProgressMessage:@"Installing preferences...."];
         [self runCommand:@"bmd installprefs"];
         [self runCommand:@"bmd installactivatorprefs"];
     }
-    if (self.hostsSwitchStatus == true) {
+    if (self.hostsSwitchStatus) {
         [self updateProgressMessage:@"Installing hosts...."];
         [self runCommand:@"bmd installhosts"];
     }
-    if (self.savedDebsSwitchStatus == true) {
+    if (self.savedDebsSwitchStatus) {
         NSString *motherMessage = [self updateProgressMessage:@"Installing saved .debs...."];
         [self runCommand:@"bmd chperms1"];
         [self installAllDebsInFolder:@"/var/mobile/BatchInstall/SavedDebs" withMotherMessage:motherMessage];
     }
-    if (self.offlineTweaksSwitchStatus == true) {
+    if (self.offlineTweaksSwitchStatus) {
         NSString *motherMessage = [self updateProgressMessage:@"Installing offline .debs...."];
         [self runCommand:@"bmd chperms2"];
         [self installAllDebsInFolder:@"/var/mobile/BatchInstall/OfflineDebs" withMotherMessage:motherMessage];
     }
-    if (self.reposSwitchStatus == true) {
+    if (self.reposSwitchStatus) {
         [self updateProgressMessage:@"Adding repos...."];
         [self addRepos];
         return;
     }
-    if (self.tweaksSwitchStatus == true) {
+    if (self.tweaksSwitchStatus) {
         [self processingReposDidFinish:true];
         return;
     }
@@ -333,7 +333,7 @@ int refreshesCompleted = 0;
     }
     // this means the package manager finished adding repos
     else {
-        if (self.tweaksSwitchStatus == true) {
+        if (self.tweaksSwitchStatus) {
             if (shouldTransition) {
                 [self updateProgressMessage:@"Queuing tweaks...."];
                 [self queueTweaks:shouldTransition];
@@ -706,7 +706,7 @@ int refreshesCompleted = 0;
 
 // Queues all currently-installed tweaks for removal in the current package manager
 - (void)removeAllTweaks {
-    if (self.removeAllTweaksSwitchStatus == true) {
+    if (self.removeAllTweaksSwitchStatus) {
         [self runCommand:@"bmd removealltweaks 1"];
     }
     else {
@@ -884,7 +884,7 @@ int refreshesCompleted = 0;
                           shouldOpenBMHomeViewControllerFirst:(BOOL)shouldOpenBMHomeViewControllerFirst {
     UIAlertAction *proceedAction = [UIAlertAction
         actionWithTitle:@"Proceed" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            if (self.uicacheSwitchStatus == true && self.respringSwitchStatus == false) {
+            if (self.uicacheSwitchStatus && !self.respringSwitchStatus) {
                 [self showProcessingDialog:@"Running uicache...." includeStage:false startingStep:1 autoPresent:true];
                 [self runCommand:@"uicache --all"];
                 
@@ -900,11 +900,11 @@ int refreshesCompleted = 0;
                 [self.processingDialog addAction:okAction];
             }
             
-            else if (self.uicacheSwitchStatus == false && self.respringSwitchStatus == true) {
+            else if (!self.uicacheSwitchStatus && self.respringSwitchStatus) {
                 [self runCommand:@"sbreload"];
             }
             
-            else if (self.uicacheSwitchStatus == true && self.respringSwitchStatus == true) {
+            else if (self.uicacheSwitchStatus && self.respringSwitchStatus) {
                 NSString *dialog = @"Running uicache and respringing....";
                 [self showProcessingDialog:dialog includeStage:false startingStep:1 autoPresent:true];
                 [self runCommand:@"uicache --all --respring"];
@@ -940,7 +940,7 @@ int refreshesCompleted = 0;
         ];
         [alert addAction:proceedAction];
         [alert addAction:doNothingAction];
-        if (theMessage == nil) {
+        if (!theMessage) {
             [self placeUISwitchInsideUIAlertController:alert whichScreen:4];
         }
         else {

--- a/Batchomatic.xm
+++ b/Batchomatic.xm
@@ -285,7 +285,27 @@ int refreshesCompleted = 0;
             [self.processingDialog dismissViewControllerAnimated:YES completion:^{
                 [self.bm_BMInstallTableViewController dismissViewControllerAnimated:YES completion:^{
                     [self.bm_BMHomeTableViewController dismissViewControllerAnimated:YES completion:^{
-                        [self.zebra_ZBRepoListTableViewController didAddReposWithText:reposToAdd];
+                        if ([self.zebra_sourcesVC respondsToSelector:@selector(didAddReposWithText:)]) {
+                            [self.zebra_sourcesVC didAddReposWithText:reposToAdd];
+                        } else {
+                            NSArray *splitSources = [reposToAdd componentsSeparatedByString:@"\n"];
+                            NSMutableArray *actualURLs = [NSMutableArray new];
+                            for (NSString *s in splitSources) {
+                                NSURL *url = [NSURL URLWithString:s];
+                                if (url) {
+                                    [actualURLs addObject:url];
+                                }
+                            }
+                            NSSet *sources = [%c(ZBBaseSource) baseSourcesFromURLs:actualURLs];
+
+                            if ([self.zebra_sourcesManager respondsToSelector:@selector(addBaseSources:)]) {
+                                [self.zebra_sourcesManager addBaseSources:sources];
+                            } else if ([self.zebra_sourcesManager respondsToSelector:@selector(addSources:error:)]) {
+                                // TODO: handle error
+                                // NSError *error = nil;
+                                [self.zebra_sourcesManager addSources:sources error:nil];
+                            }
+                        }
                     }];
                 }];
             }];
@@ -667,7 +687,7 @@ int refreshesCompleted = 0;
         }
         
         UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
-        [self.zebra_ZBRepoListTableViewController refreshSources:refreshControl];
+        [self.zebra_sourcesVC refreshSources:refreshControl];
     }
     
     // Sileo

--- a/Batchomatic.xm
+++ b/Batchomatic.xm
@@ -321,7 +321,7 @@ int refreshesCompleted = 0;
 
 // After each package manager finishes adding repos,
 // this method is called to continue running Batchomatic
-- (void)processingReposDidFinish:(bool)shouldTransition {
+- (void)processingReposDidFinish:(BOOL)shouldTransition {
     refreshesCompleted = 0;
     // this means the package manager finished removing repos
     if (self.isRemovingRepos) {
@@ -361,7 +361,7 @@ int refreshesCompleted = 0;
 // Displays an alert if we cannot find some of the user's tweaks.
 // This is caused when the repo for said tweak is not added, or said tweak
 // was previously installed from a .deb. We obviously can't queue a tweak if we can't find it
-- (void)showUnfindableTweaks:(NSMutableString *)unfindableTweaks transition:(bool)shouldTransition {
+- (void)showUnfindableTweaks:(NSMutableString *)unfindableTweaks transition:(BOOL)shouldTransition {
     if ([unfindableTweaks isEqualToString:@""]) {
         [self.processingDialog dismissViewControllerAnimated:YES completion:^{
             [self openQueueForCurrentPackageManager:shouldTransition];
@@ -393,7 +393,7 @@ int refreshesCompleted = 0;
 }
 
 // Adds all of the user's tweaks to the queue if they are not already installed
-- (void)queueTweaks:(bool)shouldTransition {
+- (void)queueTweaks:(BOOL)shouldTransition {
     NSMutableString *unfindableTweaks = [[NSMutableString alloc] init];
     FILE *listOfTweaksFile = fopen("/var/mobile/BatchInstall/tweaks.txt", "r");
     
@@ -495,7 +495,7 @@ int refreshesCompleted = 0;
 }
 
 // Opens the install queue for the current package manager
-- (void)openQueueForCurrentPackageManager:(bool)shouldTransition {
+- (void)openQueueForCurrentPackageManager:(BOOL)shouldTransition {
     if (shouldTransition) {
         [self.bm_BMInstallTableViewController dismissViewControllerAnimated:YES completion:^{
             [self.bm_BMHomeTableViewController dismissViewControllerAnimated:YES completion:^{
@@ -525,7 +525,7 @@ int refreshesCompleted = 0;
 
 // In Sileo, check for any current dependency errors, add those
 // dependencies to the queue, and then re-check via method recursion
-- (void)sileoFixDependencies:(NSMutableString *)unfindableTweaks transition:(bool)shouldTransition {
+- (void)sileoFixDependencies:(NSMutableString *)unfindableTweaks transition:(BOOL)shouldTransition {
     [self sileoAddDependenciesToQueue];
     [[%c(_TtC5Sileo15DownloadManager) shared] reloadDataWithRecheckPackages:true];
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0*NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
@@ -800,9 +800,9 @@ int refreshesCompleted = 0;
 // Displays a UIAlertController with stages (for example: "Stage
 // 1/4"), what we are doing, and a UIActivityIndicator/spinning wheel
 - (NSString *)showProcessingDialog:(NSString *)wordMessage
-                      includeStage:(bool)includeStage
+                      includeStage:(BOOL)includeStage
                       startingStep:(int)startingStep
-                       autoPresent:(bool)shouldAutoPresentDialog {
+                       autoPresent:(BOOL)shouldAutoPresentDialog {
     NSString *totalMessage;
     if (includeStage) {
         self.currentStep = startingStep;
@@ -880,8 +880,8 @@ int refreshesCompleted = 0;
 // Removes the UIActivityIndicator, transitions the text, and asks
 // the user if they want to uicache/respring. This method can either
 // present a whole new UIAlertController or transition an existing one
-- (void)endProcessingDialog:(NSString *)theMessage transition:(bool)shouldTransition
-                          shouldOpenBMHomeViewControllerFirst:(bool)shouldOpenBMHomeViewControllerFirst {
+- (void)endProcessingDialog:(NSString *)theMessage transition:(BOOL)shouldTransition
+                          shouldOpenBMHomeViewControllerFirst:(BOOL)shouldOpenBMHomeViewControllerFirst {
     UIAlertAction *proceedAction = [UIAlertAction
         actionWithTitle:@"Proceed" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
             if (self.uicacheSwitchStatus == true && self.respringSwitchStatus == false) {
@@ -998,7 +998,7 @@ int refreshesCompleted = 0;
 // methods to handle my special tweak preferences (asking the user
 // what they want to do for installing a .deb, removing all tweaks/repos, and uicache/respringing)
 // Creates a UIStackView with a UISwitch and a UILabel.
-// The status of the switch is stored in the boolean variables prefsSwitchStatus, tweaksSwitchStatus, etc.
+// The status of the switch is stored in the BOOLean variables prefsSwitchStatus, tweaksSwitchStatus, etc.
 - (UIStackView *)createASwitchWithLabel:(NSString *)message tag:(int)theTag defaultState:(BOOL)onOrOff {
     UILabel *theLabel = [[UILabel alloc] init];
     theLabel.text = message;

--- a/Batchomatic.xm
+++ b/Batchomatic.xm
@@ -178,12 +178,12 @@ int refreshesCompleted = 0;
         return;
     }
     if (self.tweaksSwitchStatus) {
-        [self processingReposDidFinish:true];
+        [self processingReposDidFinish:YES];
         return;
     }
     [self endProcessingDialog:@"Done! Succesfully installed your .deb!"
-        transition:true
-        shouldOpenBMHomeViewControllerFirst:false
+        transition:YES
+        shouldOpenBMHomeViewControllerFirst:NO
     ];
 }
 
@@ -300,7 +300,7 @@ int refreshesCompleted = 0;
         else if (self.packageManager == 4) {
             while (!feof(listOfReposFile)) {
                 NSString *eachRepo = [self readEachLineOfFile:listOfReposFile];
-                [self.installer_ManageViewController addSourceWithString:eachRepo withHttpApproval:true];
+                [self.installer_ManageViewController addSourceWithString:eachRepo withHttpApproval:YES];
             }
             
             [self.processingDialog dismissViewControllerAnimated:YES completion:^{
@@ -313,7 +313,7 @@ int refreshesCompleted = 0;
         }
     }
     else {
-        [self processingReposDidFinish:true];
+        [self processingReposDidFinish:YES];
     }
     fclose(listOfReposFile);
     [self runCommand:@"bmd rmtemp"];
@@ -325,10 +325,10 @@ int refreshesCompleted = 0;
     refreshesCompleted = 0;
     // this means the package manager finished removing repos
     if (self.isRemovingRepos) {
-        self.isRemovingRepos = false;
+        self.isRemovingRepos = NO;
         [self endProcessingDialog:@"Done! Succesfully removed all repos!"
             transition:shouldTransition
-            shouldOpenBMHomeViewControllerFirst:false
+            shouldOpenBMHomeViewControllerFirst:NO
         ];
     }
     // this means the package manager finished adding repos
@@ -340,9 +340,9 @@ int refreshesCompleted = 0;
             }
             else {
                 [self showProcessingDialog:@"Queuing tweaks...."
-                    includeStage:true
+                    includeStage:YES
                     startingStep:(self.currentStep + 1)
-                    autoPresent:false
+                    autoPresent:NO
                 ];
                 [self.motherClass presentViewController:self.processingDialog animated:YES completion:^{
                     [self queueTweaks:shouldTransition];
@@ -461,7 +461,7 @@ int refreshesCompleted = 0;
             }
         }
         
-        [[%c(_TtC5Sileo15DownloadManager) shared] reloadDataWithRecheckPackages:true];
+        [[%c(_TtC5Sileo15DownloadManager) shared] reloadDataWithRecheckPackages:YES];
         // dispatch_after is necessary because Sileo takes a few seconds to update the amount of dependency errors
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0*NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             // see "- (void)sileoFixDependencies" for an explanation about this
@@ -500,7 +500,7 @@ int refreshesCompleted = 0;
         [self.bm_BMInstallTableViewController dismissViewControllerAnimated:YES completion:^{
             [self.bm_BMHomeTableViewController dismissViewControllerAnimated:YES completion:^{
                 // do method recursion because I like code-reuse
-                [self openQueueForCurrentPackageManager:false];
+                [self openQueueForCurrentPackageManager:NO];
             }];
         }];
     }
@@ -527,7 +527,7 @@ int refreshesCompleted = 0;
 // dependencies to the queue, and then re-check via method recursion
 - (void)sileoFixDependencies:(NSMutableString *)unfindableTweaks transition:(BOOL)shouldTransition {
     [self sileoAddDependenciesToQueue];
-    [[%c(_TtC5Sileo15DownloadManager) shared] reloadDataWithRecheckPackages:true];
+    [[%c(_TtC5Sileo15DownloadManager) shared] reloadDataWithRecheckPackages:YES];
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0*NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if ([[[%c(_TtC5Sileo15DownloadManager) shared] errors] count] != 0) {
             // method recursion
@@ -597,7 +597,7 @@ int refreshesCompleted = 0;
 
 // Removes all currently-added repos from the current package manager
 - (void)removeAllRepos {
-    self.isRemovingRepos = true;
+    self.isRemovingRepos = YES;
     NSMutableArray *ignoredRepos = [[NSMutableArray alloc] init];
     FILE *ignoredReposFile = fopen("/Library/Batchomatic/ignoredrepos.txt", "r");
     while (!feof(ignoredReposFile)) {
@@ -700,7 +700,7 @@ int refreshesCompleted = 0;
             }
             [(ATRSources *)[[%c(ATRPackageManager) sharedPackageManager] sources] removeSourceWithLocation:url];
         }
-        [self processingReposDidFinish:true];
+        [self processingReposDidFinish:YES];
     }
 }
 
@@ -764,7 +764,7 @@ int refreshesCompleted = 0;
             }
         }
         
-        [[%c(_TtC5Sileo15DownloadManager) shared] reloadDataWithRecheckPackages:true];
+        [[%c(_TtC5Sileo15DownloadManager) shared] reloadDataWithRecheckPackages:YES];
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0*NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             [self.processingDialog dismissViewControllerAnimated:YES completion:^{
                 [self.bm_BMHomeTableViewController dismissViewControllerAnimated:YES completion:^{
@@ -885,7 +885,7 @@ int refreshesCompleted = 0;
     UIAlertAction *proceedAction = [UIAlertAction
         actionWithTitle:@"Proceed" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
             if (self.uicacheSwitchStatus && !self.respringSwitchStatus) {
-                [self showProcessingDialog:@"Running uicache...." includeStage:false startingStep:1 autoPresent:true];
+                [self showProcessingDialog:@"Running uicache...." includeStage:NO startingStep:1 autoPresent:YES];
                 [self runCommand:@"uicache --all"];
                 
                 [self transitionProgressMessage:@"Done!"];
@@ -906,7 +906,7 @@ int refreshesCompleted = 0;
             
             else if (self.uicacheSwitchStatus && self.respringSwitchStatus) {
                 NSString *dialog = @"Running uicache and respringing....";
-                [self showProcessingDialog:dialog includeStage:false startingStep:1 autoPresent:true];
+                [self showProcessingDialog:dialog includeStage:NO startingStep:1 autoPresent:YES];
                 [self runCommand:@"uicache --all --respring"];
             }
             
@@ -1030,19 +1030,19 @@ int refreshesCompleted = 0;
     // type 1 means the remove all repos screen
     if (type == 1) {
         [combinedStackView addArrangedSubview:[self createASwitchWithLabel:@"Remove everything?" tag:101 defaultState:NO]];
-        self.removeAllReposSwitchStatus = false;
+        self.removeAllReposSwitchStatus = NO;
     }
     // type 2 is the remove all tweaks screen
     else if (type == 2) {
         [combinedStackView addArrangedSubview:[self createASwitchWithLabel:@"Remove everything?" tag:102 defaultState:NO]];
-        self.removeAllTweaksSwitchStatus = false;
+        self.removeAllTweaksSwitchStatus = NO;
     }
     // type 3 is the respring/uicache screen
     else {
         [combinedStackView addArrangedSubview:[self createASwitchWithLabel:@"Run uicache" tag:103 defaultState:NO]];
         [combinedStackView addArrangedSubview:[self createASwitchWithLabel:@"Respring" tag:104 defaultState:YES]];
-        self.uicacheSwitchStatus = false;
-        self.respringSwitchStatus = true;
+        self.uicacheSwitchStatus = NO;
+        self.respringSwitchStatus = YES;
     }
     return combinedStackView;
 }
@@ -1082,44 +1082,44 @@ int refreshesCompleted = 0;
     // sorry about this terrible formatting. I figured that with such
     // repetitive code, less lines would make it easier to read. idk
     if (sender.tag == 0) {
-        if ([sender isOn]) { self.prefsSwitchStatus = true; }
-        else {               self.prefsSwitchStatus = false; }
+        if ([sender isOn]) { self.prefsSwitchStatus = YES; }
+        else {               self.prefsSwitchStatus = NO; }
     }
     else if (sender.tag == 1) {
-        if ([sender isOn]) { self.hostsSwitchStatus = true; }
-        else {               self.hostsSwitchStatus = false; }
+        if ([sender isOn]) { self.hostsSwitchStatus = YES; }
+        else {               self.hostsSwitchStatus = NO; }
     }
     else if (sender.tag == 2) {
-        if ([sender isOn]) { self.savedDebsSwitchStatus = true; }
-        else {               self.savedDebsSwitchStatus = false; }
+        if ([sender isOn]) { self.savedDebsSwitchStatus = YES; }
+        else {               self.savedDebsSwitchStatus = NO; }
     }
     else if (sender.tag == 3) {
-        if ([sender isOn]) { self.reposSwitchStatus = true; }
-        else {               self.reposSwitchStatus = false; }
+        if ([sender isOn]) { self.reposSwitchStatus = YES; }
+        else {               self.reposSwitchStatus = NO; }
     }
     else if (sender.tag == 4) {
-        if ([sender isOn]) { self.tweaksSwitchStatus = true; }
-        else {               self.tweaksSwitchStatus = false; }
+        if ([sender isOn]) { self.tweaksSwitchStatus = YES; }
+        else {               self.tweaksSwitchStatus = NO; }
     }
     else if (sender.tag == 5) {
-        if ([sender isOn]) { self.offlineTweaksSwitchStatus = true; }
-        else {               self.offlineTweaksSwitchStatus = false; }
+        if ([sender isOn]) { self.offlineTweaksSwitchStatus = YES; }
+        else {               self.offlineTweaksSwitchStatus = NO; }
     }
     else if (sender.tag == 101) {
-        if ([sender isOn]) { self.removeAllReposSwitchStatus = true; }
-        else {               self.removeAllReposSwitchStatus = false; }
+        if ([sender isOn]) { self.removeAllReposSwitchStatus = YES; }
+        else {               self.removeAllReposSwitchStatus = NO; }
     }
     else if (sender.tag == 102) {
-        if ([sender isOn]) { self.removeAllTweaksSwitchStatus = true; }
-        else {               self.removeAllTweaksSwitchStatus = false; }
+        if ([sender isOn]) { self.removeAllTweaksSwitchStatus = YES; }
+        else {               self.removeAllTweaksSwitchStatus = NO; }
     }
     else if (sender.tag == 103) {
-        if ([sender isOn]) { self.uicacheSwitchStatus = true; }
-        else {               self.uicacheSwitchStatus = false; }
+        if ([sender isOn]) { self.uicacheSwitchStatus = YES; }
+        else {               self.uicacheSwitchStatus = NO; }
     }
     else if (sender.tag == 104) {
-        if ([sender isOn]) { self.respringSwitchStatus = true; }
-        else {               self.respringSwitchStatus = false; }
+        if ([sender isOn]) { self.respringSwitchStatus = YES; }
+        else {               self.respringSwitchStatus = NO; }
     }
 }
 
@@ -1129,19 +1129,19 @@ int refreshesCompleted = 0;
 - (void)determineInfoAboutDeb {
     // determine if the user's .deb is currently installed
     if ([[self runCommand:@"dpkg -l | grep \"com.you.batchinstall\""] isEqualToString:@""]) {
-        self.debIsInstalled = false;
+        self.debIsInstalled = NO;
     }
     else {
-        self.debIsInstalled = true;
+        self.debIsInstalled = YES;
     }
     
     BOOL isFolder;
     // determine if the currently installed .deb is meant for online mode or offline mode
     if ([[NSFileManager defaultManager] fileExistsAtPath:@"/var/mobile/BatchInstall/OfflineDebs" isDirectory:&isFolder]) {
-        self.debIsOnline = false;
+        self.debIsOnline = NO;
     }
     else {
-        self.debIsOnline = true;
+        self.debIsOnline = YES;
     }
 }
 

--- a/Batchomatic.xm
+++ b/Batchomatic.xm
@@ -1,6 +1,15 @@
+//
+//  Batchomatic.xm
+//  Batchomatic
+//  
+//  Created by Capt Inc on 2020-06-01
+//  Copyright © 2020 Capt Inc. All rights reserved.
+//
+
 #import "Headers/Batchomatic.h"
 #import "Headers/BMHomeTableViewController.h"
 #import "Headers/NSTask.h"
+
 // This variable tells my tweak if we are currently adding repos so it can
 // detect when adding repos is finished. Because it needs to survive Batchomatic
 // dismissed & reopened, it must be a global extern C variable instead of an @property

--- a/Batchomatic.xm
+++ b/Batchomatic.xm
@@ -1,11 +1,15 @@
 #import "Headers/Batchomatic.h"
 #import "Headers/BMHomeTableViewController.h"
 #import "Headers/NSTask.h"
-extern int refreshesCompleted; //This variable tells my tweak if we are currently adding repos so it can detect when adding repos is finished. Because it needs to survive Batchomatic being dismissed & reopened, it must be a global extern C variable instead of an @property
+// This variable tells my tweak if we are currently adding repos so it can
+// detect when adding repos is finished. Because it needs to survive Batchomatic
+// dismissed & reopened, it must be a global extern C variable instead of an @property
+extern int refreshesCompleted;
 int refreshesCompleted = 0;
 
 @implementation Batchomatic
-+ (instancetype)sharedInstance { //Returns the instance of the Batchomatic class so you can access this code from anywhere
+// Returns the instance of the Batchomatic class so you can access this code from anywhere
++ (instancetype)sharedInstance {
     static Batchomatic *singleton;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -14,9 +18,16 @@ int refreshesCompleted = 0;
     return singleton;
 }
 
-+ (void)placeButton:(UIViewController *)sender { //Creates the Batchomatic button from my icon and places it in the navigation bar
-    NSBundle *bundle = [NSBundle bundleWithPath:@"/Library/Batchomatic/Icon.bundle"]; //you should use a bundle to get the icon and provide @3x and @2x versions. that way, iOS can choose the best resolution for your device
-    UIImage *icon = [[UIImage imageNamed:@"Icon" inBundle:bundle compatibleWithTraitCollection:nil] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+// Creates the Batchomatic button from my icon and places it in the navigation bar
++ (void)placeButton:(UIViewController *)sender {
+    // you should use a bundle to get the icon and provide
+    // @3x and @2x versions. that way, iOS can choose the best resolution for your device
+    NSBundle *bundle = [NSBundle bundleWithPath:@"/Library/Batchomatic/Icon.bundle"];
+    UIImage *icon = [[UIImage imageNamed:@"Icon"
+        inBundle:bundle
+        compatibleWithTraitCollection:nil]
+        imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate
+    ];
     
     UIButton *btn = [UIButton buttonWithType:UIButtonTypeCustom];
     [btn setImage:icon forState:UIControlStateNormal];
@@ -24,24 +35,39 @@ int refreshesCompleted = 0;
     sender.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:btn];
 }
 
-+ (void)openMainScreen:(UIViewController *)sender { //Opens the main Batchomatic UI
+// Opens the main Batchomatic UI
++ (void)openMainScreen:(UIViewController *)sender {
     UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:[[BMHomeTableViewController alloc] init]];
     [sender presentViewController:nav animated:YES completion:nil];
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-//methods for the UI of creating/installing a .deb
-- (void)createDeb:(int)type withMotherMessage:(NSString *)motherMessage { //Creates a .deb with all of the necessary information. A few other methods need to be called before calling this one. See BMHomeTableViewController.xm for more info
-    NSArray *onlineSteps = @[@"Running initial setup", @"Setting up filesystem", @"Creating control file", @"Gathering tweaks", @"Gathering repos", @"Gathering tweak preferences", @"Gathering hosts file", @"Gathering saved debs", @"Building final deb", @"Verifying deb"];
-    NSArray *offlineSteps = @[@"Running initial setup", @"Setting up filesystem", @"Creating control file", @"Gathering tweak preferences", @"Gathering hosts file", @"Gathering saved debs", @"Preparing", @"Building final deb", @"Verifying deb"];
+// methods for the UI of creating/installing a .deb
+
+// Creates a .deb with all of the necessary information. A few other methods
+// need to be called before calling this one. See BMHomeTableViewController.xm for more info
+- (void)createDeb:(int)type withMotherMessage:(NSString *)motherMessage {
+    NSArray *onlineSteps = @[
+        @"Running initial setup", @"Setting up filesystem", @"Creating control file",
+        @"Gathering tweaks", @"Gathering repos", @"Gathering tweak preferences",
+        @"Gathering hosts file", @"Gathering saved debs", @"Building final deb", @"Verifying deb"
+    ];
+    NSArray *offlineSteps = @[
+        @"Running initial setup", @"Setting up filesystem", @"Creating control file",
+        @"Gathering tweak preferences", @"Gathering hosts file", @"Gathering saved debs",
+        @"Preparing", @"Building final deb", @"Verifying deb"
+    ];
     
-    if (type == 1) { //type 1 means an online .deb with tweaks, repos, saved .debs, tweak preferences, and hosts file
+    // type 1 means an online .deb with tweaks, repos, saved .debs, tweak preferences, and hosts file
+    if (type == 1) {
         for (int x = 0; x < 10; x++) {
             [self transitionProgressMessage:[NSString stringWithFormat:@"%@%@", motherMessage, [onlineSteps objectAtIndex:x]]];
             [self runCommand:[NSString stringWithFormat:@"bmd online %d", (x+1)]];
         }
     }
-    else { //type 2 means an offline .deb with .debs of your tweaks, saved .debs, tweak preferences, and hosts file. A plain list of repos/tweaks is not included
+    // type 2 means an offline .deb with .debs of your tweaks, saved .debs,
+    // tweak preferences, and hosts file. A plain list of repos/tweaks is not included
+    else {
         for (int x = 0; x < 7; x++) {
             [self transitionProgressMessage:[NSString stringWithFormat:@"%@%@", motherMessage, [offlineSteps objectAtIndex:x]]];
             [self runCommand:[NSString stringWithFormat:@"bmd offline %d", (x+1)]];
@@ -63,16 +89,29 @@ int refreshesCompleted = 0;
         }
     }
     
-    FILE *file = fopen("/tmp/batchomatic/nameOfDeb.txt", "r"); //ensures the created deb is valid and usable
+    // ensures the created deb is valid and usable
+    FILE *file = fopen("/tmp/batchomatic/nameOfDeb.txt", "r");
     NSString *debFileName = [self readEachLineOfFile:file];
     fclose(file);
     if ([debFileName isEqualToString:@"everythingbroke"]) {
-        [self transitionProgressMessage:@"Error: creation of your .deb failed\nTry deleting /var/mobile/Library/Preferences/com.rpetrich.pictureinpicture.license, /var/mobile/Library/Preferences/BackupAZ3, and /var/mobile/Library/Preferences/Slices. Then try again\n\nIf that does not fix it, please contact me: https://reddit.com/u/captinc37"];
+        [self transitionProgressMessage:@"Error: creation of your .deb failed\n"
+            "Try deleting /var/mobile/Library/Preferences/com.rpetrich.pictureinpicture.license, "
+            "/var/mobile/Library/Preferences/BackupAZ3, and /var/mobile/Library/Preferences/Slices. "
+            "Then try again\n\nIf that does not fix it, please contact me: https://reddit.com/u/captinc37"
+        ];
         [self.spinner stopAnimating];
-        UIAlertAction *contactAction = [UIAlertAction actionWithTitle:@"Contact developer" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            NSDictionary *options = @{UIApplicationOpenURLOptionUniversalLinksOnly:@NO};
-            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://www.reddit.com/message/compose/?to=captinc37&subject=Batchomatic%20creation%20error"] options:options completionHandler:nil];
-        }];
+        UIAlertAction *contactAction = [UIAlertAction
+            actionWithTitle:@"Contact developer" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+                NSDictionary *options = @{UIApplicationOpenURLOptionUniversalLinksOnly:@NO};
+                [[UIApplication sharedApplication]
+                    openURL:[NSURL URLWithString:@"https://www.reddit.com/message/compose/"
+                        "?to=captinc37&subject=Batchomatic%20creation%20error"
+                    ]
+                    options:options
+                    completionHandler:nil
+                ];
+            }
+        ];
         UIAlertAction *dismissAction = [UIAlertAction actionWithTitle:@"Dismiss" style:UIAlertActionStyleCancel handler:nil];
         [self.processingDialog addAction:contactAction];
         [self.processingDialog addAction:dismissAction];
@@ -82,7 +121,9 @@ int refreshesCompleted = 0;
     }
 }
 
-- (void)calculateMaxStepsForInstalling { //Calculates how many stages there will be based on what toggles the user turned on. This method is only called when installing a .deb
+// Calculates how many stages there will be based on what toggles the
+// user turned on. This method is only called when installing a .deb
+- (void)calculateMaxStepsForInstalling {
     self.maxSteps = 0;
     if (self.prefsSwitchStatus == true) {
         self.maxSteps++;
@@ -108,7 +149,10 @@ int refreshesCompleted = 0;
     }
 }
 
-- (void)installDeb { //Actually performs the actions that the user wants. A few other methods need to be called before calling this one. See BMInstallTableViewController.xm for more info
+// Actually performs the actions that the user wants.
+// A few other methods need to be called before calling this one.
+// See BMInstallTableViewController.xm for more info
+- (void)installDeb {
     if (self.prefsSwitchStatus == true) {
         [self updateProgressMessage:@"Installing preferences...."];
         [self runCommand:@"bmd installprefs"];
@@ -137,28 +181,50 @@ int refreshesCompleted = 0;
         [self processingReposDidFinish:true];
         return;
     }
-    [self endProcessingDialog:@"Done! Succesfully installed your .deb!" transition:true shouldOpenBMHomeViewControllerFirst:false];
+    [self endProcessingDialog:@"Done! Succesfully installed your .deb!"
+        transition:true
+        shouldOpenBMHomeViewControllerFirst:false
+    ];
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-//methods for the back-end of installing a .deb
-- (void)installAllDebsInFolder:(NSString *)pathToDebsFolder withMotherMessage:(NSString *)motherMessage { //Installs all .debs at the given folder and updates the UIAlertController about what .deb is being installed right now. This interfaces with the binary I made to run a command as root (see the 'bmd' folder)
+// methods for the back-end of installing a .deb
+
+// Installs all .debs at the given folder and updates the UIAlertController
+// about what .deb is being installed right now. This interfaces with
+// the binary I made to run a command as root (see the 'bmd' folder)
+- (void)installAllDebsInFolder:(NSString *)pathToDebsFolder withMotherMessage:(NSString *)motherMessage {
     [self runCommand:@"bmd rmtemp"];
     [self runCommand:@"mkdir -p /tmp/batchomatic/tempdebs"];
-    [self runCommand:[NSString stringWithFormat:@"mv %@%@", pathToDebsFolder, @"/com.captinc.batchomatic*.deb /tmp/batchomatic/tempdebs"]]; //if we install the .deb for the currently-in-use package manager, it will crash
+    // if we install the .deb for the currently-in-use package manager, it will crash
+    [self runCommand:[NSString stringWithFormat:
+        @"mv %@%@", pathToDebsFolder,
+        @"/com.captinc.batchomatic*.deb /tmp/batchomatic/tempdebs"
+    ]];
     if (self.packageManager == 2) {
-        [self runCommand:[NSString stringWithFormat:@"mv %@%@", pathToDebsFolder, @"/xyz.willy.zebra*.deb /tmp/batchomatic/tempdebs"]];
+        [self runCommand:[NSString stringWithFormat:
+            @"mv %@%@", pathToDebsFolder,
+            @"/xyz.willy.zebra*.deb /tmp/batchomatic/tempdebs"
+        ]];
     }
     if (self.packageManager == 4) {
-        [self runCommand:[NSString stringWithFormat:@"mv %@%@", pathToDebsFolder, @"/me.apptapp.installer*.deb /tmp/batchomatic/tempdebs"]];
+        [self runCommand:[NSString stringWithFormat:
+            @"mv %@%@", pathToDebsFolder,
+            @"/me.apptapp.installer*.deb /tmp/batchomatic/tempdebs"
+        ]];
     }
     
     NSDirectoryEnumerator *directoryEnumerator = [[NSFileManager defaultManager] enumeratorAtPath:pathToDebsFolder];
     for (NSString *debFileName in directoryEnumerator) {
         if ([[debFileName pathExtension] isEqualToString:@"deb"]) {
-            NSString *thePackageIdentifer = [self runCommand:[NSString stringWithFormat:@"prefix=\" Package: \" && dpkg --info %@%@%@%@", pathToDebsFolder, @"/", debFileName, @" | grep \"Package: \" | sed -e \"s/^$prefix//\""]];
+            NSString *thePackageIdentifer = [self runCommand:[NSString stringWithFormat:
+                @"prefix=\" Package: \" && dpkg --info %@%@%@%@",
+                pathToDebsFolder, @"/", debFileName,
+                @" | grep \"Package: \" | sed -e \"s/^$prefix//\""
+            ]];
             [self transitionProgressMessage:[NSString stringWithFormat:@"%@%@%@", motherMessage, @"\n", thePackageIdentifer]];
-            [self runCommand:[NSString stringWithFormat:@"bmd installdeb %@%@%@", pathToDebsFolder, @"/", debFileName]]; //FYI, "bmd" means "batchomatic daemon" or "batchomaticd"
+            // FYI, "bmd" means "batchomatic daemon" or "batchomaticd"
+            [self runCommand:[NSString stringWithFormat:@"bmd installdeb %@%@%@", pathToDebsFolder, @"/", debFileName]];
         }
     }
     
@@ -167,29 +233,46 @@ int refreshesCompleted = 0;
     [self runCommand:@"rm -r /tmp/batchomatic"];
 }
 
-- (void)addRepos { //Adds all of the user's repos to the current package manager if they are not already added. Code for this feature is continued in my %hooks and then comes back to "- (void)processingReposDidFinish:" in this file. This is because we need to wait for repos to finish adding before we can proceed
-    refreshesCompleted = 1; //global extern C variable
+// Adds all of the user's repos to the current package manager if
+// they are not already added. Code for this feature is continued
+// in my %hooks and then comes back to "- (void)processingReposDidFinish:"
+// in this file. This is because we need to wait for repos to finish adding before we can proceed
+- (void)addRepos {
+    // global extern C variable
+    refreshesCompleted = 1;
     [self runCommand:[NSString stringWithFormat:@"bmd addrepos %d", self.packageManager]];
     FILE *listOfReposFile = fopen("/tmp/batchomatic/reposToAdd.txt", "r");
     
-    if ([[NSFileManager defaultManager] fileExistsAtPath:@"/tmp/batchomatic/reposToAdd.txt" isDirectory:NULL]) { //this bash script determines what repos we want versus what repos are already added
-        if (self.packageManager == 1) { //if we are using Cydia
+    // this bash script determines what repos we want versus what repos are already added
+    if ([[NSFileManager defaultManager] fileExistsAtPath:@"/tmp/batchomatic/reposToAdd.txt" isDirectory:NULL]) {
+        // if we are using Cydia
+        if (self.packageManager == 1) {
             Cydia *cydiaDelegate = (Cydia *)[[UIApplication sharedApplication] delegate];
             while (!feof(listOfReposFile)) {
                 NSString *eachRepo = [self readEachLineOfFile:listOfReposFile];
-                if ([eachRepo isEqualToString:@"http://apt.thebigboss.org/repofiles/cydia/"] || [eachRepo isEqualToString:@"http://apt.modmyi.com/"] || [eachRepo isEqualToString:@"http://cydia.zodttd.com/repo/cydia/"]) {
-                    NSDictionary *dictionary = @{@"Distribution":@"stable", @"Sections":[NSArray arrayWithObject:@"main"], @"Type":@"deb", @"URI":eachRepo};
+                if ([eachRepo isEqualToString:@"http://apt.thebigboss.org/repofiles/cydia/"] ||
+                    [eachRepo isEqualToString:@"http://apt.modmyi.com/"] ||
+                    [eachRepo isEqualToString:@"http://cydia.zodttd.com/repo/cydia/"]) {
+                    NSDictionary *dictionary = @{
+                        @"Distribution":@"stable", @"Sections":@[@"main"], @"Type":@"deb", @"URI":eachRepo
+                    };
                     [cydiaDelegate addSource:dictionary];
                 }
                 else {
                     [cydiaDelegate addTrivialSource:eachRepo];
                 }
             }
-            [cydiaDelegate requestUpdate]; //must refresh Cydia sources twice for changes to take effect. see Tweak.xm for more info
+            // must refresh Cydia sources twice for changes
+            // to take effect. see Tweak.xm for more info
+            [cydiaDelegate requestUpdate];
         }
         
-        else if (self.packageManager == 2) { //if we are using Zebra
-            NSString *reposToAdd = [NSString stringWithContentsOfFile:@"/tmp/batchomatic/reposToAdd.txt" encoding:NSUTF8StringEncoding error:nil];
+        // if we are using Zebra
+        else if (self.packageManager == 2) {
+            NSString *reposToAdd = [NSString
+                stringWithContentsOfFile:@"/tmp/batchomatic/reposToAdd.txt"
+                encoding:NSUTF8StringEncoding error:nil
+            ];
             [self.processingDialog dismissViewControllerAnimated:YES completion:^{
                 [self.bm_BMInstallTableViewController dismissViewControllerAnimated:YES completion:^{
                     [self.bm_BMHomeTableViewController dismissViewControllerAnimated:YES completion:^{
@@ -199,7 +282,8 @@ int refreshesCompleted = 0;
             }];
         }
         
-        else if (self.packageManager == 3) { //if we are using Sileo
+        // if we are using Sileo
+        else if (self.packageManager == 3) {
             NSMutableArray *reposToAdd = [[NSMutableArray alloc] init];
             while (!feof(listOfReposFile)) {
                 NSString *eachRepo = [self readEachLineOfFile:listOfReposFile];
@@ -212,7 +296,8 @@ int refreshesCompleted = 0;
             [self.sileo_SourcesViewController refreshSources:refreshControl];
         }
         
-        else if (self.packageManager == 4) { //if we are using Installer
+        // if we are using Installer
+        else if (self.packageManager == 4) {
             while (!feof(listOfReposFile)) {
                 NSString *eachRepo = [self readEachLineOfFile:listOfReposFile];
                 [self.installer_ManageViewController addSourceWithString:eachRepo withHttpApproval:true];
@@ -234,59 +319,86 @@ int refreshesCompleted = 0;
     [self runCommand:@"bmd rmtemp"];
 }
 
-- (void)processingReposDidFinish:(bool)shouldTransition { //After each package manager finishes adding repos, this method is called to continue running Batchomatic
+// After each package manager finishes adding repos,
+// this method is called to continue running Batchomatic
+- (void)processingReposDidFinish:(bool)shouldTransition {
     refreshesCompleted = 0;
-    if (self.isRemovingRepos) { //this means the package manager finished removing repos
+    // this means the package manager finished removing repos
+    if (self.isRemovingRepos) {
         self.isRemovingRepos = false;
-        [self endProcessingDialog:@"Done! Succesfully removed all repos!" transition:shouldTransition shouldOpenBMHomeViewControllerFirst:false];
+        [self endProcessingDialog:@"Done! Succesfully removed all repos!"
+            transition:shouldTransition
+            shouldOpenBMHomeViewControllerFirst:false
+        ];
     }
-    else { //this means the package manager finished adding repos
+    // this means the package manager finished adding repos
+    else {
         if (self.tweaksSwitchStatus == true) {
             if (shouldTransition) {
                 [self updateProgressMessage:@"Queuing tweaks...."];
                 [self queueTweaks:shouldTransition];
             }
             else {
-                [self showProcessingDialog:@"Queuing tweaks...." includeStage:true startingStep:(self.currentStep + 1) autoPresent:false];
+                [self showProcessingDialog:@"Queuing tweaks...."
+                    includeStage:true
+                    startingStep:(self.currentStep + 1)
+                    autoPresent:false
+                ];
                 [self.motherClass presentViewController:self.processingDialog animated:YES completion:^{
                     [self queueTweaks:shouldTransition];
                 }];
             }
         }
         else {
-            [self endProcessingDialog:@"Done! Succesfully installed your .deb!" transition:shouldTransition shouldOpenBMHomeViewControllerFirst:!shouldTransition];
+            [self endProcessingDialog:@"Done! Succesfully installed your .deb!"
+                transition:shouldTransition
+                shouldOpenBMHomeViewControllerFirst:!shouldTransition
+            ];
         }
     }
 }
 
-- (void)showUnfindableTweaks:(NSMutableString *)unfindableTweaks transition:(bool)shouldTransition { //Displays an alert if we cannot find some of the user's tweaks. This is caused when the repo for said tweak is not added, or said tweak was previously installed from a .deb. We obviously can't queue a tweak if we can't find it
+// Displays an alert if we cannot find some of the user's tweaks.
+// This is caused when the repo for said tweak is not added, or said tweak
+// was previously installed from a .deb. We obviously can't queue a tweak if we can't find it
+- (void)showUnfindableTweaks:(NSMutableString *)unfindableTweaks transition:(bool)shouldTransition {
     if ([unfindableTweaks isEqualToString:@""]) {
         [self.processingDialog dismissViewControllerAnimated:YES completion:^{
             [self openQueueForCurrentPackageManager:shouldTransition];
         }];
     }
     else {
-        NSString *message = [NSString stringWithFormat:@"The following tweaks could not be found:\n\n%@", unfindableTweaks];
+        NSString *message = [@"The following tweaks could not be found:\n\n"
+            stringByAppendingString:unfindableTweaks
+        ];
         [self transitionProgressMessage:message];
         [self.spinner stopAnimating];
-        UIAlertAction *copyAction = [UIAlertAction actionWithTitle:@"Copy to clipboard and proceed" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
-            pasteboard.string = unfindableTweaks;
-            [self openQueueForCurrentPackageManager:shouldTransition];
-        }];
-        UIAlertAction *proceedAction = [UIAlertAction actionWithTitle:@"Proceed" style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
-            [self openQueueForCurrentPackageManager:shouldTransition];
-        }];
+        UIAlertAction *copyAction = [UIAlertAction
+            actionWithTitle:@"Copy to clipboard and proceed"
+            style:UIAlertActionStyleDefault
+            handler:^(UIAlertAction *action) {
+                UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
+                pasteboard.string = unfindableTweaks;
+                [self openQueueForCurrentPackageManager:shouldTransition];
+            }
+        ];
+        UIAlertAction *proceedAction = [UIAlertAction
+            actionWithTitle:@"Proceed" style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
+                [self openQueueForCurrentPackageManager:shouldTransition];
+            }
+        ];
         [self.processingDialog addAction:copyAction];
         [self.processingDialog addAction:proceedAction];
     }
 }
 
-- (void)queueTweaks:(bool)shouldTransition { //Adds all of the user's tweaks to the queue if they are not already installed
+// Adds all of the user's tweaks to the queue if they are not already installed
+- (void)queueTweaks:(bool)shouldTransition {
     NSMutableString *unfindableTweaks = [[NSMutableString alloc] init];
     FILE *listOfTweaksFile = fopen("/var/mobile/BatchInstall/tweaks.txt", "r");
     
-    if (self.packageManager == 1) { //Cydia
+    // Cydia
+    if (self.packageManager == 1) {
         while (!feof(listOfTweaksFile)) {
             NSString *thePackageIdentifer = [self readEachLineOfFile:listOfTweaksFile];
             Package *thePackage = (Package *)[[%c(Database) sharedInstance] packageWithName:thePackageIdentifer];
@@ -306,7 +418,8 @@ int refreshesCompleted = 0;
         [self showUnfindableTweaks:unfindableTweaks transition:shouldTransition];
     }
     
-    else if (self.packageManager == 2) { //Zebra
+    // Zebra
+    else if (self.packageManager == 2) {
         ZBDatabaseManager *zebraDatabase = [%c(ZBDatabaseManager) sharedInstance];
         ZBQueue *zebraQueue = [%c(ZBQueue) sharedQueue];
         ZBQueueType zebraInstall = ZBQueueTypeInstall;
@@ -325,12 +438,15 @@ int refreshesCompleted = 0;
             }
         }
         
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0*NSEC_PER_SEC)), dispatch_get_main_queue(), ^{ //dispatch_after is necessary because Zebra lags when you open a queue with a ton of packages. this way, the user experiences less lag
+        // dispatch_after is necessary because Zebra lags when you open
+        // a queue with a ton of packages. this way, the user experiences less lag
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0*NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             [self showUnfindableTweaks:unfindableTweaks transition:shouldTransition];
         });
     }
     
-    else if (self.packageManager == 3) { //Sileo
+    // Sileo
+    else if (self.packageManager == 3) {
         while (!feof(listOfTweaksFile)) {
             NSString *thePackageIdentifer = [self readEachLineOfFile:listOfTweaksFile];
             _TtC5Sileo7Package *thePackage = [[%c(_TtC5Sileo18PackageListManager) shared] newestPackageWithIdentifier:thePackageIdentifer];
@@ -346,8 +462,10 @@ int refreshesCompleted = 0;
         }
         
         [[%c(_TtC5Sileo15DownloadManager) shared] reloadDataWithRecheckPackages:true];
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0*NSEC_PER_SEC)), dispatch_get_main_queue(), ^{ //dispatch_after is necessary because Sileo takes a few seconds to update the amount of dependency errors
-            if ([[[%c(_TtC5Sileo15DownloadManager) shared] errors] count] != 0) { //see "- (void)sileoFixDependencies" for an explanation about this
+        // dispatch_after is necessary because Sileo takes a few seconds to update the amount of dependency errors
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0*NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            // see "- (void)sileoFixDependencies" for an explanation about this
+            if ([[[%c(_TtC5Sileo15DownloadManager) shared] errors] count] != 0) {
                 [self sileoFixDependencies:unfindableTweaks transition:shouldTransition];
             }
             else {
@@ -356,7 +474,8 @@ int refreshesCompleted = 0;
         });
     }
     
-    else if (self.packageManager == 4) { //Installer
+    // Installer
+    else if (self.packageManager == 4) {
         while (!feof(listOfTweaksFile)) {
             NSString *thePackageIdentifer = [self readEachLineOfFile:listOfTweaksFile];
             ATRPackages *pkgs = [[%c(ATRPackageManager) sharedPackageManager] packages];
@@ -375,11 +494,13 @@ int refreshesCompleted = 0;
     fclose(listOfTweaksFile);
 }
 
-- (void)openQueueForCurrentPackageManager:(bool)shouldTransition { //Opens the install queue for the current package manager
+// Opens the install queue for the current package manager
+- (void)openQueueForCurrentPackageManager:(bool)shouldTransition {
     if (shouldTransition) {
         [self.bm_BMInstallTableViewController dismissViewControllerAnimated:YES completion:^{
             [self.bm_BMHomeTableViewController dismissViewControllerAnimated:YES completion:^{
-                [self openQueueForCurrentPackageManager:false]; //do method recursion because I like code-reuse
+                // do method recursion because I like code-reuse
+                [self openQueueForCurrentPackageManager:false];
             }];
         }];
     }
@@ -400,13 +521,17 @@ int refreshesCompleted = 0;
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-//methods to make Sileo add the dependencies of your tweaks to the queue since Sileo doesn't do that by default
-- (void)sileoFixDependencies:(NSMutableString *)unfindableTweaks transition:(bool)shouldTransition { //In Sileo, check for any current dependency errors, add those dependencies to the queue, and then re-check via method recursion
+// methods to make Sileo add the dependencies of your tweaks to the queue since Sileo doesn't do that by default
+
+// In Sileo, check for any current dependency errors, add those
+// dependencies to the queue, and then re-check via method recursion
+- (void)sileoFixDependencies:(NSMutableString *)unfindableTweaks transition:(bool)shouldTransition {
     [self sileoAddDependenciesToQueue];
     [[%c(_TtC5Sileo15DownloadManager) shared] reloadDataWithRecheckPackages:true];
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0*NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if ([[[%c(_TtC5Sileo15DownloadManager) shared] errors] count] != 0) {
-            [self sileoFixDependencies:unfindableTweaks transition:shouldTransition]; //method recursion
+            // method recursion
+            [self sileoFixDependencies:unfindableTweaks transition:shouldTransition];
         }
         else {
             [self showUnfindableTweaks:unfindableTweaks transition:shouldTransition];
@@ -414,7 +539,9 @@ int refreshesCompleted = 0;
     });
 }
 
-- (void)sileoAddDependenciesToQueue { //Resolves any current dependency problems when queuing tweaks in Sileo. After running this method, you need to check for dependency problems again
+// Resolves any current dependency problems when queuing tweaks in Sileo.
+// After running this method, you need to check for dependency problems again
+- (void)sileoAddDependenciesToQueue {
     NSArray *sileoErrors = [[%c(_TtC5Sileo15DownloadManager) shared] errors];
     NSMutableArray *unfoundDependenciesAsArray = [[NSMutableArray alloc] init];
     for (int i = 0; i < [sileoErrors count]; i++) {
@@ -425,7 +552,8 @@ int refreshesCompleted = 0;
     NSOrderedSet *orderedSet = [NSOrderedSet orderedSetWithArray:unfoundDependenciesAsArray];
     NSArray *middleMan = [orderedSet array];
     NSMutableArray *arrayWithoutDuplicates = [middleMan mutableCopy];
-    if ([arrayWithoutDuplicates containsObject:@"org.thebigboss.libcolorpicker"] && [arrayWithoutDuplicates containsObject:@"me.nepeta.libcolorpicker"]) {
+    if ([arrayWithoutDuplicates containsObject:@"org.thebigboss.libcolorpicker"] &&
+        [arrayWithoutDuplicates containsObject:@"me.nepeta.libcolorpicker"]) {
         [arrayWithoutDuplicates removeObject:@"org.thebigboss.libcolorpicker"];
     }
     
@@ -433,7 +561,8 @@ int refreshesCompleted = 0;
         NSString *thePackageIdentifer = [arrayWithoutDuplicates objectAtIndex:i];
         _TtC5Sileo7Package *thePackage = [[%c(_TtC5Sileo18PackageListManager) shared] newestPackageWithIdentifier:thePackageIdentifer];
         if (thePackage != nil) {
-            if ([[%c(_TtC5Sileo18PackageListManager) shared] installedPackageWithIdentifier:thePackageIdentifer] == nil && ![[[%c(_TtC5Sileo15DownloadManager) shared] installations] containsObject:thePackage]) {
+            if ([[%c(_TtC5Sileo18PackageListManager) shared] installedPackageWithIdentifier:thePackageIdentifer] == nil &&
+                ![[[%c(_TtC5Sileo15DownloadManager) shared] installations] containsObject:thePackage]) {
                 [[%c(_TtC5Sileo15DownloadManager) shared] addWithPackage:thePackage queue:1];
             }
         }
@@ -441,8 +570,9 @@ int refreshesCompleted = 0;
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-//methods to repack an installed tweak to a .deb and remove all tweaks and repos
-- (void)repackTweakWithIdentifier:(NSString *)packageID { //Repacks the specified package identifier to a .deb
+// methods to repack an installed tweak to a .deb and remove all tweaks and repos
+// Repacks the specified package identifier to a .deb
+- (void)repackTweakWithIdentifier:(NSString *)packageID {
     [self runCommand:[NSString stringWithFormat:@"bmd deb %@", packageID]];
     
     FILE *file = fopen("/tmp/batchomatic/nameOfDeb.txt", "r");
@@ -450,7 +580,11 @@ int refreshesCompleted = 0;
     fclose(file);
     
     if ([debFileName isEqualToString:@"debcreationfailed"]) {
-        NSString *msg = [NSString stringWithFormat:@"Error: creation of the .deb for this tweak failed. This is most likely a problem with that particular tweak\n\nTry running \"bmd deb %@%@", packageID, @"\" in Terminal for more information"];
+        NSString *msg = [NSString stringWithFormat:
+            @"Error: creation of the .deb for this tweak failed. "
+            "This is most likely a problem with that particular tweak\n\n"
+            "Try running \"bmd deb %@%@", packageID, @"\" in Terminal for more information"
+        ];
         [self transitionProgressMessage:msg];
         [self.spinner stopAnimating];
         UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleCancel handler:nil];
@@ -461,7 +595,8 @@ int refreshesCompleted = 0;
     }
 }
 
-- (void)removeAllRepos { //Removes all currently-added repos from the current package manager
+// Removes all currently-added repos from the current package manager
+- (void)removeAllRepos {
     self.isRemovingRepos = true;
     NSMutableArray *ignoredRepos = [[NSMutableArray alloc] init];
     FILE *ignoredReposFile = fopen("/Library/Batchomatic/ignoredrepos.txt", "r");
@@ -474,10 +609,16 @@ int refreshesCompleted = 0;
     [ignoredRepos addObject:@"http://apt.thebigboss.org/repofiles/cydia/"];
     [ignoredRepos addObject:@"https://repounclutter.coolstar.org/"];
     
-    if (self.packageManager == 1) { //Cydia
+    // Cydia
+    if (self.packageManager == 1) {
         refreshesCompleted = 1;
         NSArray *allRepos = [[[%c(Database) sharedInstance] sources] copy];
-        NSArray *cannotBeRemoved = @[@"http://apt.bingner.com/", @"https://apt.bingner.com/", @"https://checkra.in/assets/mobilesubstrate/", @"https://diatr.us/apt/"];
+        NSArray *cannotBeRemoved = @[
+            @"http://apt.bingner.com/",
+            @"https://apt.bingner.com/",
+            @"https://checkra.in/assets/mobilesubstrate/",
+            @"https://diatr.us/apt/"
+        ];
         for (int x = 0; x < [allRepos count]; x++) {
             NSString *url = [(Source *)[allRepos objectAtIndex:x] rooturi];
             if ([cannotBeRemoved containsObject:url]) {
@@ -491,7 +632,8 @@ int refreshesCompleted = 0;
         [(Cydia *)[[UIApplication sharedApplication] delegate] requestUpdate];
     }
     
-    else if (self.packageManager == 2) { //Zebra
+    // Zebra
+    else if (self.packageManager == 2) {
         for (int x = 0; x < [ignoredRepos count]; x++) {
             NSString *url = [ignoredRepos objectAtIndex:x];
             if ([url hasPrefix:@"http://"]) {
@@ -519,10 +661,17 @@ int refreshesCompleted = 0;
         [self.zebra_ZBRepoListTableViewController refreshSources:refreshControl];
     }
     
-    else if (self.packageManager == 3) { //Sileo
+    // Sileo
+    else if (self.packageManager == 3) {
         refreshesCompleted = 1;
         NSArray *allRepos = [[%c(_TtC5Sileo11RepoManager) shared] repoList];
-        NSArray *cannotBeRemoved = @[@"https://repo.chimera.sh/", @"https://checkra.in/assets/mobilesubstrate/", @"https://diatr.us/dark/", @"https://diatr.us/sileodark/", @"https://diatr.us/apt/"];
+        NSArray *cannotBeRemoved = @[
+            @"https://repo.chimera.sh/",
+            @"https://checkra.in/assets/mobilesubstrate/",
+            @"https://diatr.us/dark/",
+            @"https://diatr.us/sileodark/",
+            @"https://diatr.us/apt/"
+        ];
         for (int x = 0; x < [allRepos count]; x++) {
             NSString *url = [(_TtC5Sileo4Repo *)[allRepos objectAtIndex:x] repoURL];
             if ([cannotBeRemoved containsObject:url]) {
@@ -538,7 +687,8 @@ int refreshesCompleted = 0;
         [self.sileo_SourcesViewController refreshSources:refreshControl];
     }
     
-    else if (self.packageManager == 4) { //Installer
+    // Installer
+    else if (self.packageManager == 4) {
         NSArray *allRepos = [[(ATRSources *)[[%c(ATRPackageManager) sharedPackageManager] sources] arrayOfConfiguredSources] copy];
         for (int x = 0; x < [allRepos count]; x++) {
             NSString *url = [allRepos objectAtIndex:x];
@@ -554,7 +704,8 @@ int refreshesCompleted = 0;
     }
 }
 
-- (void)removeAllTweaks { //Queues all currently-installed tweaks for removal in the current package manager
+// Queues all currently-installed tweaks for removal in the current package manager
+- (void)removeAllTweaks {
     if (self.removeAllTweaksSwitchStatus == true) {
         [self runCommand:@"bmd removealltweaks 1"];
     }
@@ -563,7 +714,8 @@ int refreshesCompleted = 0;
     }
     FILE *removeAllTweaksFile = fopen("/tmp/batchomatic/removealltweaks.txt", "r");
     
-    if (self.packageManager == 1) { //Cydia
+    // Cydia
+    if (self.packageManager == 1) {
         while (!feof(removeAllTweaksFile)) {
             NSString *thePackageIdentifer = [self readEachLineOfFile:removeAllTweaksFile];
             Package *thePackage = (Package *)[[%c(Database) sharedInstance] packageWithName:thePackageIdentifer];
@@ -581,7 +733,8 @@ int refreshesCompleted = 0;
         }];
     }
     
-    else if (self.packageManager == 2) { //Zebra
+    // Zebra
+    else if (self.packageManager == 2) {
         ZBDatabaseManager *zebraDatabase = [%c(ZBDatabaseManager) sharedInstance];
         ZBQueue *zebraQueue = [%c(ZBQueue) sharedQueue];
         ZBQueueType zebraRemove = ZBQueueTypeRemove;
@@ -601,7 +754,8 @@ int refreshesCompleted = 0;
         }];
     }
     
-    else if (self.packageManager == 3) { //Sileo
+    // Sileo
+    else if (self.packageManager == 3) {
         while (!feof(removeAllTweaksFile)) {
             NSString *thePackageIdentifer = [self readEachLineOfFile:removeAllTweaksFile];
             if ([[%c(_TtC5Sileo18PackageListManager) shared] installedPackageWithIdentifier:thePackageIdentifer] != nil) {
@@ -620,7 +774,8 @@ int refreshesCompleted = 0;
         });
     }
     
-    else if (self.packageManager == 4) { //Installer
+    // Installer
+    else if (self.packageManager == 4) {
         while (!feof(removeAllTweaksFile)) {
             NSString *thePackageIdentifer = [self readEachLineOfFile:removeAllTweaksFile];
             ATRPackages *pkgs = [[%c(ATRPackageManager) sharedPackageManager] packages];
@@ -640,31 +795,49 @@ int refreshesCompleted = 0;
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-//methods to handle presenting/dismissing the processing dialog
-- (NSString *)showProcessingDialog:(NSString *)wordMessage includeStage:(bool)includeStage startingStep:(int)startingStep autoPresent:(bool)shouldAutoPresentDialog { //Displays a UIAlertController with stages (for example: "Stage 1/4"), what we are doing, and a UIActivityIndicator/spinning wheel
+// methods to handle presenting/dismissing the processing dialog
+
+// Displays a UIAlertController with stages (for example: "Stage
+// 1/4"), what we are doing, and a UIActivityIndicator/spinning wheel
+- (NSString *)showProcessingDialog:(NSString *)wordMessage
+                      includeStage:(bool)includeStage
+                      startingStep:(int)startingStep
+                       autoPresent:(bool)shouldAutoPresentDialog {
     NSString *totalMessage;
     if (includeStage) {
         self.currentStep = startingStep;
         NSString *currentStepAsString = [NSString stringWithFormat:@"%d", self.currentStep];
         NSString *maxStepsAsString = [NSString stringWithFormat:@"%d", self.maxSteps];
-        totalMessage = [NSString stringWithFormat:@"Stage %@%@%@%@%@", currentStepAsString, @"/", maxStepsAsString, @"\n", wordMessage];
+        totalMessage = [NSString stringWithFormat:
+            @"Stage %@%@%@%@%@", currentStepAsString, @"/", maxStepsAsString, @"\n", wordMessage
+        ];
     }
     else {
         totalMessage = wordMessage;
     }
-    self.processingDialog = [UIAlertController alertControllerWithTitle:@"Batchomatic" message:totalMessage preferredStyle:UIAlertControllerStyleAlert];
+    self.processingDialog = [UIAlertController
+        alertControllerWithTitle:@"Batchomatic"
+        message:totalMessage
+        preferredStyle:UIAlertControllerStyleAlert
+    ];
     
-    UIActivityIndicatorView *spinner; //create a UIActivityIndicator inside a UIAlertController
+    // create a UIActivityIndicator inside a UIAlertController
+    UIActivityIndicatorView *spinner;
     if (@available(iOS 13, *)) {
-        spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
+        spinner = [[UIActivityIndicatorView alloc]
+            initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium
+        ];
     }
     else {
-        spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+        spinner = [[UIActivityIndicatorView alloc]
+            initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray
+        ];
     }
     UIViewController *spinnerVC = [[UIViewController alloc] init];
     [spinnerVC.view addSubview:spinner];
     
-    UILayoutGuide *margin = spinnerVC.view.layoutMarginsGuide; //center the UIActivityIndicator
+    // center the UIActivityIndicator
+    UILayoutGuide *margin = spinnerVC.view.layoutMarginsGuide;
     [spinner.centerXAnchor constraintEqualToAnchor:margin.centerXAnchor].active = YES;
     [spinner.centerYAnchor constraintEqualToAnchor:margin.centerYAnchor].active = YES;
     
@@ -673,18 +846,29 @@ int refreshesCompleted = 0;
     [spinner startAnimating];
     self.spinner = spinner;
     if (shouldAutoPresentDialog) {
-        [self.bm_currentBMController presentViewController:self.processingDialog animated:YES completion:nil];
+        [self.bm_currentBMController
+            presentViewController:self.processingDialog
+            animated:YES
+            completion:nil
+        ];
     }
     return totalMessage;
 }
 
-- (void)transitionProgressMessage:(NSString *)theMessage { //Only transitions the text of the processing dialog
-    [UIView transitionWithView:self.processingDialog.view duration:0.3 options:UIViewAnimationOptionTransitionCrossDissolve animations:^(void) {
-        self.processingDialog.message = theMessage;
-    } completion:nil];
+// Only transitions the text of the processing dialog
+- (void)transitionProgressMessage:(NSString *)theMessage {
+    [UIView transitionWithView:self.processingDialog.view
+        duration:0.3
+        options:UIViewAnimationOptionTransitionCrossDissolve
+        animations:^(void) {
+            self.processingDialog.message = theMessage;
+        }
+        completion:nil
+    ];
 }
 
-- (NSString *)updateProgressMessage:(NSString *)wordMessage { //Increments what stage we are on and transitions the text
+// Increments what stage we are on and transitions the text
+- (NSString *)updateProgressMessage:(NSString *)wordMessage {
     self.currentStep++;
     NSString *currentStepAsString = [NSString stringWithFormat:@"%d", self.currentStep];
     NSString *maxStepsAsString = [NSString stringWithFormat:@"%d", self.maxSteps];
@@ -693,42 +877,53 @@ int refreshesCompleted = 0;
     return totalMessage;
 }
 
-- (void)endProcessingDialog:(NSString *)theMessage transition:(bool)shouldTransition shouldOpenBMHomeViewControllerFirst:(bool)shouldOpenBMHomeViewControllerFirst { //Removes the UIActivityIndicator, transitions the text, and asks the user if they want to uicache/respring. This method can either present a whole new UIAlertController or transition an existing one
-    UIAlertAction *proceedAction = [UIAlertAction actionWithTitle:@"Proceed" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-        if (self.uicacheSwitchStatus == true && self.respringSwitchStatus == false) {
-            [self showProcessingDialog:@"Running uicache...." includeStage:false startingStep:1 autoPresent:true];
-            [self runCommand:@"uicache --all"];
+// Removes the UIActivityIndicator, transitions the text, and asks
+// the user if they want to uicache/respring. This method can either
+// present a whole new UIAlertController or transition an existing one
+- (void)endProcessingDialog:(NSString *)theMessage transition:(bool)shouldTransition
+                          shouldOpenBMHomeViewControllerFirst:(bool)shouldOpenBMHomeViewControllerFirst {
+    UIAlertAction *proceedAction = [UIAlertAction
+        actionWithTitle:@"Proceed" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+            if (self.uicacheSwitchStatus == true && self.respringSwitchStatus == false) {
+                [self showProcessingDialog:@"Running uicache...." includeStage:false startingStep:1 autoPresent:true];
+                [self runCommand:@"uicache --all"];
+                
+                [self transitionProgressMessage:@"Done!"];
+                [self.spinner stopAnimating];
+                UIAlertAction *okAction = [UIAlertAction
+                    actionWithTitle:@"Ok" style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
+                        if ([self.bm_currentBMController isKindOfClass:%c(BMInstallTableViewController)]) {
+                            [self.bm_BMInstallTableViewController dismissViewControllerAnimated:YES completion:nil];
+                        }
+                    }
+                ];
+                [self.processingDialog addAction:okAction];
+            }
             
-            [self transitionProgressMessage:@"Done!"];
-            [self.spinner stopAnimating];
-            UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
+            else if (self.uicacheSwitchStatus == false && self.respringSwitchStatus == true) {
+                [self runCommand:@"sbreload"];
+            }
+            
+            else if (self.uicacheSwitchStatus == true && self.respringSwitchStatus == true) {
+                NSString *dialog = @"Running uicache and respringing....";
+                [self showProcessingDialog:dialog includeStage:false startingStep:1 autoPresent:true];
+                [self runCommand:@"uicache --all --respring"];
+            }
+            
+            else {
                 if ([self.bm_currentBMController isKindOfClass:%c(BMInstallTableViewController)]) {
                     [self.bm_BMInstallTableViewController dismissViewControllerAnimated:YES completion:nil];
                 }
-            }];
-            [self.processingDialog addAction:okAction];
+            }
         }
-        
-        else if (self.uicacheSwitchStatus == false && self.respringSwitchStatus == true) {
-            [self runCommand:@"sbreload"];
-        }
-        
-        else if (self.uicacheSwitchStatus == true && self.respringSwitchStatus == true) {
-            [self showProcessingDialog:@"Running uicache and respringing...." includeStage:false startingStep:1 autoPresent:true];
-            [self runCommand:@"uicache --all --respring"];
-        }
-        
-        else {
+    ];
+    UIAlertAction *doNothingAction = [UIAlertAction
+        actionWithTitle:@"Do nothing" style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
             if ([self.bm_currentBMController isKindOfClass:%c(BMInstallTableViewController)]) {
                 [self.bm_BMInstallTableViewController dismissViewControllerAnimated:YES completion:nil];
             }
         }
-    }];
-    UIAlertAction *doNothingAction = [UIAlertAction actionWithTitle:@"Do nothing" style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
-        if ([self.bm_currentBMController isKindOfClass:%c(BMInstallTableViewController)]) {
-            [self.bm_BMInstallTableViewController dismissViewControllerAnimated:YES completion:nil];
-        }
-    }];
+    ];
     
     if (shouldTransition) {
         [self placeUISwitchInsideUIAlertController:self.processingDialog whichScreen:3];
@@ -738,7 +933,11 @@ int refreshesCompleted = 0;
         [self.processingDialog addAction:doNothingAction];
     }
     else {
-        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Batchomatic" message:theMessage preferredStyle:UIAlertControllerStyleAlert];
+        UIAlertController *alert = [UIAlertController
+            alertControllerWithTitle:@"Batchomatic"
+            message:theMessage
+            preferredStyle:UIAlertControllerStyleAlert
+        ];
         [alert addAction:proceedAction];
         [alert addAction:doNothingAction];
         if (theMessage == nil) {
@@ -749,7 +948,9 @@ int refreshesCompleted = 0;
         }
         
         if (shouldOpenBMHomeViewControllerFirst) {
-            UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:[[BMHomeTableViewController alloc] init]];
+            UINavigationController *nav = [[UINavigationController alloc]
+                initWithRootViewController:[[BMHomeTableViewController alloc] init]
+            ];
             [self.motherClass presentViewController:nav animated:YES completion:^{
                 [self.bm_BMHomeTableViewController presentViewController:alert animated:YES completion:nil];
             }];
@@ -760,27 +961,33 @@ int refreshesCompleted = 0;
     }
 }
 
-- (void)showFinishedCreatingDialog:(NSString *)debFileName { //UI for when creating a .deb finishes. This removes the UIActivityIndicator, transitions the text, and asks the user if they want to immediately share the created .deb
+// UI for when creating a .deb finishes. This removes the UIActivityIndicator,
+// transitions the text, and asks the user if they want to immediately share the created .deb
+- (void)showFinishedCreatingDialog:(NSString *)debFileName {
     [self transitionProgressMessage:@"Done!\nSuccesfully created your .deb!\nIt's at /var/mobile/BatchomaticDebs"];
     [self.spinner stopAnimating];
-    UIAlertAction *exportAction = [UIAlertAction actionWithTitle:@"Export" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-        [self runCommand:@"bmd rmtemp"];
-        NSArray *items = @[[NSURL fileURLWithPath:[NSString stringWithFormat:@"/var/mobile/BatchomaticDebs/%@", debFileName]]];
-        UIActivityViewController *shareSheet = [[UIActivityViewController alloc] initWithActivityItems:items applicationActivities:nil];
-        [shareSheet setValue:debFileName forKey:@"subject"];
-        
-        if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) { //iPads require special positioning for the share sheet
-            shareSheet.modalPresentationStyle = UIModalPresentationPopover;
-            UIPopoverPresentationController *popPC = shareSheet.popoverPresentationController;
-            popPC.sourceView = [self.bm_currentBMController view];
-            CGRect sourceRext = CGRectZero;
-            sourceRext.origin = CGPointMake(75, 0);
-            popPC.sourceRect = sourceRext;
-            popPC.permittedArrowDirections = UIPopoverArrowDirectionUp;
+    UIAlertAction *exportAction = [UIAlertAction
+        actionWithTitle:@"Export" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+            [self runCommand:@"bmd rmtemp"];
+            NSArray *items = @[[NSURL fileURLWithPath:[NSString stringWithFormat:@"/var/mobile/BatchomaticDebs/%@", debFileName]]];
+            UIActivityViewController *shareSheet = [[UIActivityViewController alloc] initWithActivityItems:items applicationActivities:nil];
+            [shareSheet setValue:debFileName forKey:@"subject"];
+            
+            // iPads require special positioning for the share sheet
+            if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+                shareSheet.modalPresentationStyle = UIModalPresentationPopover;
+                UIPopoverPresentationController *popPC = shareSheet.popoverPresentationController;
+                popPC.sourceView = [self.bm_currentBMController view];
+                CGRect sourceRext = CGRectZero;
+                sourceRext.origin = CGPointMake(75, 0);
+                popPC.sourceRect = sourceRext;
+                popPC.permittedArrowDirections = UIPopoverArrowDirectionUp;
+            }
+            [self.bm_currentBMController presentViewController:shareSheet animated:YES completion:nil];
         }
-        [self.bm_currentBMController presentViewController:shareSheet animated:YES completion:nil];
-    }];
-    UIAlertAction *dismissAction = [UIAlertAction actionWithTitle:@"Dismiss" style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
+    ];
+    UIAlertAction *dismissAction = [UIAlertAction
+        actionWithTitle:@"Dismiss" style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
         [self runCommand:@"bmd rmtemp"];
     }];
     [self.processingDialog addAction:exportAction];
@@ -788,8 +995,11 @@ int refreshesCompleted = 0;
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-//methods to handle my special tweak preferences (asking the user what they want to do for installing a .deb, removing all tweaks/repos, and uicache/respringing)
-- (UIStackView *)createASwitchWithLabel:(NSString *)message tag:(int)theTag defaultState:(BOOL)onOrOff { //Creates a UIStackView with a UISwitch and a UILabel. The status of the switch is stored in the boolean variables prefsSwitchStatus, tweaksSwitchStatus, etc.
+// methods to handle my special tweak preferences (asking the user
+// what they want to do for installing a .deb, removing all tweaks/repos, and uicache/respringing)
+// Creates a UIStackView with a UISwitch and a UILabel.
+// The status of the switch is stored in the boolean variables prefsSwitchStatus, tweaksSwitchStatus, etc.
+- (UIStackView *)createASwitchWithLabel:(NSString *)message tag:(int)theTag defaultState:(BOOL)onOrOff {
     UILabel *theLabel = [[UILabel alloc] init];
     theLabel.text = message;
     [theLabel sizeToFit];
@@ -809,21 +1019,26 @@ int refreshesCompleted = 0;
     return stackView;
 }
 
-- (UIStackView *)createOptionsSwitches:(int)type { //Combines multiple UIStackViews from the above method to create a larger stack view that has multiple toggles/labels
+// Combines multiple UIStackViews from the above method
+// to create a larger stack view that has multiple toggles/labels
+- (UIStackView *)createOptionsSwitches:(int)type {
     UIStackView *combinedStackView = [[UIStackView alloc] init];
     combinedStackView.translatesAutoresizingMaskIntoConstraints = NO;
     combinedStackView.axis = UILayoutConstraintAxisVertical;
     combinedStackView.spacing = 10;
     
-    if (type == 1) { //type 1 means the remove all repos screen
+    // type 1 means the remove all repos screen
+    if (type == 1) {
         [combinedStackView addArrangedSubview:[self createASwitchWithLabel:@"Remove everything?" tag:101 defaultState:NO]];
         self.removeAllReposSwitchStatus = false;
     }
-    else if (type == 2) { //type 2 is the remove all tweaks screen
+    // type 2 is the remove all tweaks screen
+    else if (type == 2) {
         [combinedStackView addArrangedSubview:[self createASwitchWithLabel:@"Remove everything?" tag:102 defaultState:NO]];
         self.removeAllTweaksSwitchStatus = false;
     }
-    else { //type 3 is the respring/uicache screen
+    // type 3 is the respring/uicache screen
+    else {
         [combinedStackView addArrangedSubview:[self createASwitchWithLabel:@"Run uicache" tag:103 defaultState:NO]];
         [combinedStackView addArrangedSubview:[self createASwitchWithLabel:@"Respring" tag:104 defaultState:YES]];
         self.uicacheSwitchStatus = false;
@@ -832,7 +1047,9 @@ int refreshesCompleted = 0;
     return combinedStackView;
 }
 
-- (UIAlertController *)placeUISwitchInsideUIAlertController:(UIAlertController *)alert whichScreen:(int)screen { //Places the large stack view from the above method inside the given UIAlertController & applies some UI adjustments to make everything look good. The result is a UIAlertController with UISwitches inside
+// Places the large stack view from the above method inside the given UIAlertController
+// & applies some UI adjustments to make everything look good. The result is a UIAlertController with UISwitches inside
+- (UIAlertController *)placeUISwitchInsideUIAlertController:(UIAlertController *)alert whichScreen:(int)screen {
     int whichOptions = screen;
     if (screen == 4) {
         whichOptions = 3;
@@ -842,11 +1059,15 @@ int refreshesCompleted = 0;
     [combinedStackView.centerXAnchor constraintEqualToAnchor:alert.view.centerXAnchor].active = YES;
     
     CGFloat switchesTopAnchor = 20 + 20.5 + 20;
-    if (screen == 1 || screen == 2) { //remove all repos/tweaks screen with a 2-line message
-        switchesTopAnchor += (2 + 16 + 16); //add the height of a 2-line message plus the space between the title and the message
+    // remove all repos/tweaks screen with a 2-line message
+    if (screen == 1 || screen == 2) {
+        // add the height of a 2-line message plus the space between the title and the message
+        switchesTopAnchor += (2 + 16 + 16);
     }
-    else if (screen == 3) { //uicache/respring screen with a 1-line message
-        switchesTopAnchor += (2 + 16); //add the height of a 1-line message
+    // uicache/respring screen with a 1-line message
+    else if (screen == 3) {
+        // add the height of a 1-line message
+        switchesTopAnchor += (2 + 16);
     }
     
     [combinedStackView.topAnchor constraintEqualToAnchor:alert.view.topAnchor constant:switchesTopAnchor].active = YES;
@@ -856,8 +1077,11 @@ int refreshesCompleted = 0;
     return alert;
 }
 
-- (void)toggleTapped:(UISwitch *)sender { //Updates the corresponding xyzSwitchStatus variable whenever one of my UISwitches is tapped
-    if (sender.tag == 0) { //sorry about this terrible formatting. I figured that with such repetitive code, less lines would make it easier to read. idk
+// Updates the corresponding xyzSwitchStatus variable whenever one of my UISwitches is tapped
+- (void)toggleTapped:(UISwitch *)sender {
+    // sorry about this terrible formatting. I figured that with such
+    // repetitive code, less lines would make it easier to read. idk
+    if (sender.tag == 0) {
         if ([sender isOn]) { self.prefsSwitchStatus = true; }
         else {               self.prefsSwitchStatus = false; }
     }
@@ -900,9 +1124,11 @@ int refreshesCompleted = 0;
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-//methods to determine info about the user's .deb and load a list of currently installed tweaks into an NSArray
+// methods to determine info about the user's .deb and load a list
+// of currently installed tweaks into an NSArray
 - (void)determineInfoAboutDeb {
-    if ([[self runCommand:@"dpkg -l | grep \"com.you.batchinstall\""] isEqualToString:@""]) { //determine if the user's .deb is currently installed
+    // determine if the user's .deb is currently installed
+    if ([[self runCommand:@"dpkg -l | grep \"com.you.batchinstall\""] isEqualToString:@""]) {
         self.debIsInstalled = false;
     }
     else {
@@ -910,7 +1136,8 @@ int refreshesCompleted = 0;
     }
     
     BOOL isFolder;
-    if ([[NSFileManager defaultManager] fileExistsAtPath:@"/var/mobile/BatchInstall/OfflineDebs" isDirectory:&isFolder]) { //determine if the currently installed .deb is meant for online mode or offline mode
+    // determine if the currently installed .deb is meant for online mode or offline mode
+    if ([[NSFileManager defaultManager] fileExistsAtPath:@"/var/mobile/BatchInstall/OfflineDebs" isDirectory:&isFolder]) {
         self.debIsOnline = false;
     }
     else {
@@ -918,7 +1145,8 @@ int refreshesCompleted = 0;
     }
 }
 
-- (void)loadListOfCurrentlyInstalledTweaks { //Used only for "Repack tweak to .deb" (not used anywhere else)
+// Used only for "Repack tweak to .deb" (not used anywhere else)
+- (void)loadListOfCurrentlyInstalledTweaks {
     [self runCommand:@"bmd rmgetlist"];
     [self runCommand:@"bmd getlist"];
     
@@ -939,10 +1167,13 @@ int refreshesCompleted = 0;
     }
     fclose(file);
     
-    NSSortDescriptor *descriptor = [[NSSortDescriptor alloc] initWithKey:@"name" ascending:YES selector:@selector(caseInsensitiveCompare:)];
+    NSSortDescriptor *descriptor = [[NSSortDescriptor alloc]
+        initWithKey:@"name" ascending:YES selector:@selector(caseInsensitiveCompare:)
+    ];
     self.currentlyInstalledTweaks = [[tweaks sortedArrayUsingDescriptors:@[descriptor]] copy];
     
-    if ([self.bm_currentBMController isKindOfClass:%c(BMRepackTableViewController)]) { //when loading the list is finished, reload the tableview
+    // when loading the list is finished, reload the tableview
+    if ([self.bm_currentBMController isKindOfClass:%c(BMRepackTableViewController)]) {
         dispatch_sync(dispatch_get_main_queue(), ^{
             [self.bm_BMRepackTableViewController createTableView];
         });
@@ -952,8 +1183,10 @@ int refreshesCompleted = 0;
 }
 
 //--------------------------------------------------------------------------------------------------------------------------
-//methods to perform utility tasks
-- (NSString *)runCommand:(NSString *)theCommand { //Runs the specified shell command as "mobile" and returns the output. Running a command as root can be seen in the "bmd" folder
+// methods to perform utility tasks
+// Runs the specified shell command as "mobile" and returns the output. Running
+// a command as root can be seen in the "bmd" folder
+- (NSString *)runCommand:(NSString *)theCommand {
     NSPipe *pipe = [NSPipe pipe];
     NSFileHandle *file = pipe.fileHandleForReading;
     
@@ -970,7 +1203,8 @@ int refreshesCompleted = 0;
     return output;
 }
 
-- (NSString *)readEachLineOfFile:(FILE *)file { //Returns each line of the given file. Use this inside of a while loop
+// Returns each line of the given file. Use this inside of a while loop
+- (NSString *)readEachLineOfFile:(FILE *)file {
     NSMutableString *result = [[NSMutableString alloc] init];
     char buffer[4096];
     int charsRead;

--- a/Headers/BMHomeTableViewController.h
+++ b/Headers/BMHomeTableViewController.h
@@ -8,8 +8,6 @@
 
 @interface BMHomeTableViewController : UITableViewController
 - (NSString *)versionNumber;
-- (void)viewDidLoad;
-- (void)viewWillAppear:(BOOL)animated;
 
 - (void)createNavBar;
 - (void)createTableView;
@@ -29,6 +27,4 @@
 - (void)didTapRespringButton;
 - (void)didTapBackButton;
 - (void)didTapHelpButton;
-
-- (void)dealloc;
 @end

--- a/Headers/BMHomeTableViewController.h
+++ b/Headers/BMHomeTableViewController.h
@@ -1,3 +1,11 @@
+//
+//  BMHomeTableViewController.h
+//  Headers
+//  
+//  Created by Capt Inc on 2020-05-31
+//  Copyright © 2020 Capt Inc. All rights reserved.
+//
+
 @interface BMHomeTableViewController : UITableViewController
 - (NSString *)versionNumber;
 - (void)viewDidLoad;

--- a/Headers/BMInstallTableViewController.h
+++ b/Headers/BMInstallTableViewController.h
@@ -1,3 +1,11 @@
+//
+//  BMInstallTableViewController.h
+//  Headers
+//  
+//  Created by Capt Inc on 2020-05-31
+//  Copyright © 2020 Capt Inc. All rights reserved.
+//
+
 @interface BMInstallTableViewController : UITableViewController
 - (void)viewDidLoad;
 - (void)viewWillAppear:(BOOL)animated;

--- a/Headers/BMInstallTableViewController.h
+++ b/Headers/BMInstallTableViewController.h
@@ -7,8 +7,6 @@
 //
 
 @interface BMInstallTableViewController : UITableViewController
-- (void)viewDidLoad;
-- (void)viewWillAppear:(BOOL)animated;
 
 - (void)createTableView;
 

--- a/Headers/BMRepackTableViewController.h
+++ b/Headers/BMRepackTableViewController.h
@@ -8,8 +8,6 @@
 
 @interface BMRepackTableViewController : UITableViewController
 @property UIActivityIndicatorView *spinner;
-- (void)viewDidLoad;
-- (void)viewWillAppear:(BOOL)animated;
 
 - (void)placeActivityIndicator;
 - (void)createTableView;

--- a/Headers/BMRepackTableViewController.h
+++ b/Headers/BMRepackTableViewController.h
@@ -1,3 +1,11 @@
+//
+//  BMRepackTableViewController.h
+//  Headers
+//  
+//  Created by Capt Inc on 2020-05-31
+//  Copyright © 2020 Capt Inc. All rights reserved.
+//
+
 @interface BMRepackTableViewController : UITableViewController
 @property UIActivityIndicatorView *spinner;
 - (void)viewDidLoad;

--- a/Headers/Batchomatic.h
+++ b/Headers/Batchomatic.h
@@ -73,7 +73,7 @@
 - (void)toggleTapped:(UISwitch *)sender;
 
 - (void)determineInfoAboutDeb;
-- (void)loadListOfCurrentlyInstalledTweaks;
+- (BOOL)loadListOfCurrentlyInstalledTweaks;
 
 - (NSString *)runCommand:(NSString *)theCommand;
 - (NSString *)readEachLineOfFile:(FILE *)file;

--- a/Headers/Batchomatic.h
+++ b/Headers/Batchomatic.h
@@ -16,21 +16,21 @@
 @property (nonatomic) ATTabBarController *installer_ATTabBarController;
 @property (nonatomic) ManageViewController *installer_ManageViewController;
 
-@property (nonatomic) bool prefsSwitchStatus;
-@property (nonatomic) bool savedDebsSwitchStatus;
-@property (nonatomic) bool hostsSwitchStatus;
-@property (nonatomic) bool reposSwitchStatus;
-@property (nonatomic) bool tweaksSwitchStatus;
-@property (nonatomic) bool offlineTweaksSwitchStatus;
-@property (nonatomic) bool uicacheSwitchStatus;
-@property (nonatomic) bool respringSwitchStatus;
-@property (nonatomic) bool removeAllReposSwitchStatus;
-@property (nonatomic) bool removeAllTweaksSwitchStatus;
+@property (nonatomic) BOOL prefsSwitchStatus;
+@property (nonatomic) BOOL savedDebsSwitchStatus;
+@property (nonatomic) BOOL hostsSwitchStatus;
+@property (nonatomic) BOOL reposSwitchStatus;
+@property (nonatomic) BOOL tweaksSwitchStatus;
+@property (nonatomic) BOOL offlineTweaksSwitchStatus;
+@property (nonatomic) BOOL uicacheSwitchStatus;
+@property (nonatomic) BOOL respringSwitchStatus;
+@property (nonatomic) BOOL removeAllReposSwitchStatus;
+@property (nonatomic) BOOL removeAllTweaksSwitchStatus;
 
 @property (nonatomic) int packageManager;
-@property (nonatomic) bool isRemovingRepos;
-@property (nonatomic) bool debIsInstalled;
-@property (nonatomic) bool debIsOnline;
+@property (nonatomic) BOOL isRemovingRepos;
+@property (nonatomic) BOOL debIsInstalled;
+@property (nonatomic) BOOL debIsOnline;
 @property (nonatomic) NSArray *currentlyInstalledTweaks;
 
 @property (nonatomic) UIAlertController *processingDialog;
@@ -48,12 +48,12 @@
 
 - (void)installAllDebsInFolder:(NSString *)pathToDebsFolder withMotherMessage:(NSString *)motherMessage;
 - (void)addRepos;
-- (void)processingReposDidFinish:(bool)shouldTransition;
-- (void)showUnfindableTweaks:(NSMutableString *)unfindableTweaks transition:(bool)shouldTransition;
-- (void)queueTweaks:(bool)shouldTransition;
-- (void)openQueueForCurrentPackageManager:(bool)shouldTransition;
+- (void)processingReposDidFinish:(BOOL)shouldTransition;
+- (void)showUnfindableTweaks:(NSMutableString *)unfindableTweaks transition:(BOOL)shouldTransition;
+- (void)queueTweaks:(BOOL)shouldTransition;
+- (void)openQueueForCurrentPackageManager:(BOOL)shouldTransition;
 
-- (void)sileoFixDependencies:(NSMutableString *)unfindableTweaks transition:(bool)shouldTransition;
+- (void)sileoFixDependencies:(NSMutableString *)unfindableTweaks transition:(BOOL)shouldTransition;
 - (void)sileoAddDependenciesToQueue;
 
 - (void)repackTweakWithIdentifier:(NSString *)packageID;
@@ -61,10 +61,10 @@
 - (void)removeAllRepos;
 - (void)removeAllTweaks;
 
-- (NSString *)showProcessingDialog:(NSString *)wordMessage includeStage:(bool)includeStage startingStep:(int)startingStep autoPresent:(bool)shouldAutoPresentDialog;
+- (NSString *)showProcessingDialog:(NSString *)wordMessage includeStage:(BOOL)includeStage startingStep:(int)startingStep autoPresent:(BOOL)shouldAutoPresentDialog;
 - (void)transitionProgressMessage:(NSString *)theMessage;
 - (NSString *)updateProgressMessage:(NSString *)wordMessage;
-- (void)endProcessingDialog:(NSString *)theMessage transition:(bool)shouldTransition shouldOpenBMHomeViewControllerFirst:(bool)shouldOpenBMHomeViewControllerFirst;
+- (void)endProcessingDialog:(NSString *)theMessage transition:(BOOL)shouldTransition shouldOpenBMHomeViewControllerFirst:(BOOL)shouldOpenBMHomeViewControllerFirst;
 - (void)showFinishedCreatingDialog:(NSString *)debFileName;
 
 - (UIStackView *)createASwitchWithLabel:(NSString *)message tag:(int)theTag defaultState:(BOOL)onOrOff;

--- a/Headers/Batchomatic.h
+++ b/Headers/Batchomatic.h
@@ -11,7 +11,8 @@
 
 @property (nonatomic) id motherClass;
 @property (nonatomic) ZBTabBarController *zebra_ZBTabBarController;
-@property (nonatomic) ZBRepoListTableViewController *zebra_ZBRepoListTableViewController;
+@property (nonatomic) ZBRepoListTableViewController *zebra_sourcesVC;
+@property (nonatomic) ZBSourceManager *zebra_sourcesManager;
 @property (nonatomic) _TtC5Sileo21SourcesViewController *sileo_SourcesViewController;
 @property (nonatomic) ATTabBarController *installer_ATTabBarController;
 @property (nonatomic) ManageViewController *installer_ManageViewController;

--- a/Headers/Batchomatic.h
+++ b/Headers/Batchomatic.h
@@ -4,39 +4,39 @@
 #import "Tweak.h"
 
 @interface Batchomatic : NSObject
-@property BMHomeTableViewController *bm_BMHomeTableViewController;
-@property BMInstallTableViewController *bm_BMInstallTableViewController;
-@property BMRepackTableViewController *bm_BMRepackTableViewController;
-@property id bm_currentBMController;
+@property (nonatomic) BMHomeTableViewController *bm_BMHomeTableViewController;
+@property (nonatomic) BMInstallTableViewController *bm_BMInstallTableViewController;
+@property (nonatomic) BMRepackTableViewController *bm_BMRepackTableViewController;
+@property (nonatomic) id bm_currentBMController;
 
-@property id motherClass;
-@property ZBTabBarController *zebra_ZBTabBarController;
-@property ZBRepoListTableViewController *zebra_ZBRepoListTableViewController;
-@property _TtC5Sileo21SourcesViewController *sileo_SourcesViewController;
-@property ATTabBarController *installer_ATTabBarController;
-@property ManageViewController *installer_ManageViewController;
+@property (nonatomic) id motherClass;
+@property (nonatomic) ZBTabBarController *zebra_ZBTabBarController;
+@property (nonatomic) ZBRepoListTableViewController *zebra_ZBRepoListTableViewController;
+@property (nonatomic) _TtC5Sileo21SourcesViewController *sileo_SourcesViewController;
+@property (nonatomic) ATTabBarController *installer_ATTabBarController;
+@property (nonatomic) ManageViewController *installer_ManageViewController;
 
-@property bool prefsSwitchStatus;
-@property bool savedDebsSwitchStatus;
-@property bool hostsSwitchStatus;
-@property bool reposSwitchStatus;
-@property bool tweaksSwitchStatus;
-@property bool offlineTweaksSwitchStatus;
-@property bool uicacheSwitchStatus;
-@property bool respringSwitchStatus;
-@property bool removeAllReposSwitchStatus;
-@property bool removeAllTweaksSwitchStatus;
+@property (nonatomic) bool prefsSwitchStatus;
+@property (nonatomic) bool savedDebsSwitchStatus;
+@property (nonatomic) bool hostsSwitchStatus;
+@property (nonatomic) bool reposSwitchStatus;
+@property (nonatomic) bool tweaksSwitchStatus;
+@property (nonatomic) bool offlineTweaksSwitchStatus;
+@property (nonatomic) bool uicacheSwitchStatus;
+@property (nonatomic) bool respringSwitchStatus;
+@property (nonatomic) bool removeAllReposSwitchStatus;
+@property (nonatomic) bool removeAllTweaksSwitchStatus;
 
-@property int packageManager;
-@property bool isRemovingRepos;
-@property bool debIsInstalled;
-@property bool debIsOnline;
-@property NSArray *currentlyInstalledTweaks;
+@property (nonatomic) int packageManager;
+@property (nonatomic) bool isRemovingRepos;
+@property (nonatomic) bool debIsInstalled;
+@property (nonatomic) bool debIsOnline;
+@property (nonatomic) NSArray *currentlyInstalledTweaks;
 
-@property UIAlertController *processingDialog;
-@property UIActivityIndicatorView *spinner;
-@property int maxSteps;
-@property int currentStep;
+@property (nonatomic) UIAlertController *processingDialog;
+@property (nonatomic) UIActivityIndicatorView *spinner;
+@property (nonatomic) int maxSteps;
+@property (nonatomic) int currentStep;
 
 + (instancetype)sharedInstance;
 + (void)placeButton:(UIViewController *)sender;

--- a/Headers/Tweak.h
+++ b/Headers/Tweak.h
@@ -44,7 +44,7 @@
 
 //--------------------------------------------------------------------------------------------------------------------------
 // Zebra
-@interface ZBSearchViewController : UITableViewController
+@interface ZBSearchTableViewController : UITableViewController
 - (void)startBatchomatic;
 @end
 

--- a/Headers/Tweak.h
+++ b/Headers/Tweak.h
@@ -1,4 +1,4 @@
-//Cydia
+// Cydia
 @interface SearchController : UIViewController
 - (void)viewDidLoad;
 - (void)startBatchomatic;
@@ -36,7 +36,7 @@
 @end
 
 //--------------------------------------------------------------------------------------------------------------------------
-//Zebra
+// Zebra
 @interface ZBSearchViewController : UITableViewController
 - (void)viewDidLoad;
 - (void)startBatchomatic;
@@ -94,7 +94,7 @@ typedef enum {
 @end
 
 //--------------------------------------------------------------------------------------------------------------------------
-//Sileo
+// Sileo
 @interface _TtC5Sileo25PackageListViewController : UIViewController
 - (void)viewDidLoad;
 - (void)startBatchomatic;
@@ -138,7 +138,7 @@ typedef enum {
 @end
 
 //--------------------------------------------------------------------------------------------------------------------------
-//Installer
+// Installer
 @interface SearchViewController : UIViewController
 - (void)viewDidLoad;
 - (void)startBatchomatic;

--- a/Headers/Tweak.h
+++ b/Headers/Tweak.h
@@ -8,7 +8,6 @@
 
 // Cydia
 @interface SearchController : UIViewController
-- (void)viewDidLoad;
 - (void)startBatchomatic;
 @end
 
@@ -46,7 +45,6 @@
 //--------------------------------------------------------------------------------------------------------------------------
 // Zebra
 @interface ZBSearchViewController : UITableViewController
-- (void)viewDidLoad;
 - (void)startBatchomatic;
 @end
 
@@ -104,7 +102,6 @@ typedef enum {
 //--------------------------------------------------------------------------------------------------------------------------
 // Sileo
 @interface _TtC5Sileo25PackageListViewController : UIViewController
-- (void)viewDidLoad;
 - (void)startBatchomatic;
 @end
 
@@ -148,7 +145,6 @@ typedef enum {
 //--------------------------------------------------------------------------------------------------------------------------
 // Installer
 @interface SearchViewController : UIViewController
-- (void)viewDidLoad;
 - (void)startBatchomatic;
 @end
 

--- a/Headers/Tweak.h
+++ b/Headers/Tweak.h
@@ -52,9 +52,24 @@
 - (void)refreshSources:(id)sender;
 @end
 
+/// Later renamed to ZBSourceListTableViewController, but no matter
 @interface ZBRepoListTableViewController : ZBRefreshableTableViewController
+/// Not available with ZBSourceListTableViewController
 - (void)didAddReposWithText:(NSString *)text;
 - (void)refreshTable;
+@end
+
+@interface ZBBaseSource : NSObject
++ (NSSet<ZBBaseSource *> *)baseSourcesFromURLs:(NSArray *)URLs;
+@end
+
+@interface ZBSourceManager : NSObject
+@property (nonatomic, readonly, class) ZBSourceManager *sharedInstance;
+
+// 1.1
+- (void)addBaseSources:(NSSet<ZBBaseSource *> *)sources;
+// 1.2
+- (void)addSources:(NSSet<ZBBaseSource *> *)sources error:(NSError **)error;
 @end
 
 @interface ZBRefreshViewController : UIViewController

--- a/Headers/Tweak.h
+++ b/Headers/Tweak.h
@@ -1,3 +1,11 @@
+//
+//  Tweak.h
+//  Headers
+//  
+//  Created by Capt Inc on 2020-05-31
+//  Copyright © 2020 Capt Inc. All rights reserved.
+//
+
 // Cydia
 @interface SearchController : UIViewController
 - (void)viewDidLoad;

--- a/Headers/Tweak.h
+++ b/Headers/Tweak.h
@@ -9,7 +9,7 @@
 - (void)_loaded;
 - (void)addSource:(NSDictionary *)dictionary;
 - (BOOL)addTrivialSource:(NSString *)href;
-- (bool)requestUpdate;
+- (BOOL)requestUpdate;
 - (void)resolve;
 - (void)queue;
 @end
@@ -129,7 +129,7 @@ typedef enum {
 @property (nonatomic, copy) NSArray *installations;
 + (instancetype)shared;
 - (void)addWithPackage:(_TtC5Sileo7Package *)thePackage queue:(int)typeOfQueue;
-- (void)reloadDataWithRecheckPackages:(bool)recheck;
+- (void)reloadDataWithRecheckPackages:(BOOL)recheck;
 @end
 
 @interface TabBarController : UITabBarController
@@ -145,7 +145,7 @@ typedef enum {
 @end
 
 @interface ManageViewController : UIViewController
-- (void)addSourceWithString:(NSString *)repoURL withHttpApproval:(bool)approval;
+- (void)addSourceWithString:(NSString *)repoURL withHttpApproval:(BOOL)approval;
 @end
 
 @interface ATTabBarController : UITabBarController
@@ -162,7 +162,7 @@ typedef enum {
 
 @interface ATRPackages : NSObject
 - (ATRPackage *)packageWithIdentifier:(NSString *)packageIdentifier;
-- (bool)packageIsInstalled:(NSString *)packageIdentifier;
+- (BOOL)packageIsInstalled:(NSString *)packageIdentifier;
 - (void)setPackage:(NSString *)packageIdentifier inTheQueue:(BOOL)queue versionToQueue:(NSString *)version operation:(NSUInteger)operation;
 @end
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ARCHS = arm64 arm64e
-TARGET = iphone:clang::11.0
+TARGET = iphone:latest::13.0
 include $(THEOS)/makefiles/common.mk
 
 TWEAK_NAME = Batchomatic

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -1,3 +1,11 @@
+//
+//  Tweak.xm
+//  Batchomatic
+//  
+//  Created by Capt Inc on 2020-06-01
+//  Copyright © 2020 Capt Inc. All rights reserved.
+//
+
 #import "Headers/Batchomatic.h"
 #import "Headers/Tweak.h"
 extern int refreshesCompleted;

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -60,7 +60,7 @@ extern int refreshesCompleted;
 
 //--------------------------------------------------------------------------------------------------------------------------
 // Zebra
-%hook ZBSearchViewController
+%hook ZBSearchTableViewController
 - (void)viewDidLoad {
     %orig;
     [Batchomatic placeButton:self];

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -33,9 +33,9 @@ extern int refreshesCompleted;
         refreshesCompleted = 2;
     }
     else if (refreshesCompleted == 2) {
-        // Pass true/false for whether or not we should transition
+        // Pass YES/NO for whether or not we should transition
         // the existing processing dialog or make a new one
-        [[Batchomatic sharedInstance] processingReposDidFinish:true];
+        [[Batchomatic sharedInstance] processingReposDidFinish:YES];
     }
 }
 
@@ -78,8 +78,8 @@ extern int refreshesCompleted;
     %orig;
     if (refreshesCompleted != 0) {
         // Zebra displays a pop-up when adding repos, which dismisses my UIAlertController.
-        // So, we need to create a new UIAlertController by passing 'false'
-        [[Batchomatic sharedInstance] processingReposDidFinish:false];
+        // So, we need to create a new UIAlertController by passing 'NO'
+        [[Batchomatic sharedInstance] processingReposDidFinish:NO];
     }
 }
 %end
@@ -90,7 +90,7 @@ extern int refreshesCompleted;
     %orig;
     Batchomatic *bm = [Batchomatic sharedInstance];
     if (bm.isRemovingRepos) {
-        [bm processingReposDidFinish:true];
+        [bm processingReposDidFinish:YES];
     }
 }
 %end
@@ -131,7 +131,7 @@ extern int refreshesCompleted;
     if (refreshesCompleted != 0 && bm.packageManager == 3 && [NSStringFromClass(self.superview.class) length] == 0) {
         // Dispatch_after is necessary because Sileo takes a few seconds to update what tweaks are in the queue
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0*NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-            [bm processingReposDidFinish:true];
+            [bm processingReposDidFinish:YES];
         });
     }
 }
@@ -161,7 +161,7 @@ extern int refreshesCompleted;
 - (void)viewWillDisappear:(BOOL)animated {
     %orig;
     if (refreshesCompleted != 0) {
-        [[Batchomatic sharedInstance] processingReposDidFinish:false];
+        [[Batchomatic sharedInstance] processingReposDidFinish:NO];
     }
 }
 %end

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -71,11 +71,14 @@ extern int refreshesCompleted;
     bm.packageManager = 2;
     bm.motherClass = self;
     // This saves the instance of ZBTabBarController for later use
-    bm.zebra_ZBTabBarController = (ZBTabBarController *)self.tabBarController;
+    bm.zebra_ZBTabBarController = (id)self.tabBarController;
     UINavigationController *ctrl = self.tabBarController.viewControllers[1];
     // And this saves the instance of ZBRepoListTableViewController
-    bm.zebra_ZBRepoListTableViewController = (ZBRepoListTableViewController *)ctrl.viewControllers[0];
-    [bm.zebra_ZBRepoListTableViewController viewDidLoad];
+    bm.zebra_sourcesVC = (id)ctrl.viewControllers[0];
+    // And so on
+    bm.zebra_sourcesManager = [%c(ZBSourceManager) sharedInstance];
+    
+    [bm.zebra_sourcesVC viewDidLoad];
     [Batchomatic openMainScreen:self];
 }
 %end

--- a/bmd/ent.xml
+++ b/bmd/ent.xml
@@ -2,6 +2,6 @@
 <plist version="1.0">
     <dict>
         <key>platform-application</key>
-        <true/>
+        <YES/>
     </dict>
 </plist>

--- a/bmd/main.m
+++ b/bmd/main.m
@@ -4,7 +4,9 @@
 #import "../Headers/NSTask.h"
 #define FLAG_PLATFORMIZE (1 << 1)
 
-void fixSetuidForChimera() { //On Chimera, you have to do this fancy stuff to make yourself root (cannot simply do setuid() like unc0ver/checkra1n)
+// On Chimera, you have to do this fancy stuff to make yourself root
+// (cannot simply do setuid() like unc0ver/checkra1n)
+void fixSetuidForChimera() {
     void *handle = dlopen("/usr/lib/libjailbreak.dylib", RTLD_LAZY);
     if (!handle) {
         return;
@@ -34,20 +36,25 @@ void fixSetuidForChimera() { //On Chimera, you have to do this fancy stuff to ma
     setgid(0);
 }
 
-int main(int argc, char *argv[], char *envp[]) { //Allows you to pick one of the commands below and run it as root. Hardcoding commands instead of passing a command in the arguments is a safer and better practice
+// Allows you to pick one of the commands below and run
+// it as root. Hardcoding commands instead of passing a
+// command in the arguments is a safer and better practice
+int main(int argc, char *argv[], char *envp[]) {
     if (argc < 2) {
         printf("Error: you did not specify an option to run\n");
         return 1;
     }
     
-    setuid(0); //make us root
+    // make us root
+    setuid(0);
     if (getuid() != 0) {
         fixSetuidForChimera();
     }
     
     NSTask *task = [[NSTask alloc] init];
     NSMutableArray *args = [[NSMutableArray alloc] init];
-    if (!strcmp(argv[1], "rmtemp")) { //misc utilities
+    // misc utilities
+    if (!strcmp(argv[1], "rmtemp")) {
         [task setLaunchPath:@"/bin/rm"];
         [args addObject:@"-r"];
         [args addObject:@"/tmp/batchomatic"];
@@ -65,7 +72,8 @@ int main(int argc, char *argv[], char *envp[]) { //Allows you to pick one of the
         [args addObject:@"/var/mobile/BatchInstall/OfflineDebs"];
     }
     //--------------------------------------------------------------------------------------------------------------------------
-    else if (!strcmp(argv[1], "getlist")) { //loading a list of currently installed tweaks for the "Repack tweak to .deb" menu
+    // loading a list of currently installed tweaks for the "Repack tweak to .deb" menu
+    else if (!strcmp(argv[1], "getlist")) {
         [task setLaunchPath:@"/bin/bash"];
         [args addObject:@"/Library/Batchomatic/createonline.sh"];
         [args addObject:@"getlist"];
@@ -76,7 +84,8 @@ int main(int argc, char *argv[], char *envp[]) { //Allows you to pick one of the
         [args addObject:@"/tmp/batchomaticGetList"];
     }
     //--------------------------------------------------------------------------------------------------------------------------
-    else if (!strcmp(argv[1], "deb")) { //creating a .deb of a single tweak
+    // creating a .deb of a single tweak
+    else if (!strcmp(argv[1], "deb")) {
         if (argc > 2) {
             [task setLaunchPath:@"/usr/bin/bmd"];
             [args addObject:@"rmtemp"];
@@ -97,7 +106,8 @@ int main(int argc, char *argv[], char *envp[]) { //Allows you to pick one of the
         }
     }
     //--------------------------------------------------------------------------------------------------------------------------
-    else if (!strcmp(argv[1], "installprefs")) { //installing the .deb
+    // installing the .deb
+    else if (!strcmp(argv[1], "installprefs")) {
         [task setLaunchPath:@"/bin/cp"];
         [args addObject:@"-r"];
         [args addObject:@"/var/mobile/BatchInstall/Preferences/*"];
@@ -153,14 +163,16 @@ int main(int argc, char *argv[], char *envp[]) { //Allows you to pick one of the
         [args addObject:[NSString stringWithFormat:@"%s", argv[2]]];
     }
     //--------------------------------------------------------------------------------------------------------------------------
-    else if (!strcmp(argv[1], "online")) { //running each stage of creating an online deb
+    // running each stage of creating an online deb
+    else if (!strcmp(argv[1], "online")) {
         if (!strcmp(argv[2], "all")) {
             [task setLaunchPath:@"/bin/bash"];
             [args addObject:@"/Library/Batchomatic/createonline.sh"];
             [args addObject:@"all"];
         }
         else {
-            char *p; //convert a string from argv[] to an int to verify that the user chose a valid step
+            // convert a string from argv[] to an int to verify that the user chose a valid step
+            char *p;
             errno = 0;
             long arg = strtol(argv[2], &p, 10);
             if (*p != '\0' || errno != 0) {
@@ -183,7 +195,8 @@ int main(int argc, char *argv[], char *envp[]) { //Allows you to pick one of the
         }
     }
     //--------------------------------------------------------------------------------------------------------------------------
-    else if (!strcmp(argv[1], "offline")) { //running each stage of creating an offline deb
+    // running each stage of creating an offline deb
+    else if (!strcmp(argv[1], "offline")) {
         if (!strcmp(argv[2], "all")) {
             [task setLaunchPath:@"/bin/bash"];
             [args addObject:@"/Library/Batchomatic/createoffline.sh"];

--- a/layout/DEBIAN/control
+++ b/layout/DEBIAN/control
@@ -1,6 +1,6 @@
 Package: com.captinc.batchomatic
 Name: Batchomatic
-Version: 4.3.1
+Version: 4.4.0
 Depends: firmware (>=11.0), mobilesubstrate, coreutils
 Author: Capt Inc <teamcaptinc@gmail.com>
 Maintainer: Capt Inc <teamcaptinc@gmail.com>

--- a/layout/Library/Batchomatic/determinerepostoadd.sh
+++ b/layout/Library/Batchomatic/determinerepostoadd.sh
@@ -24,16 +24,16 @@ mkdir /tmp/batchomatic
 cp /var/mobile/BatchInstall/repos.txt /tmp/batchomatic/wantedReposRaw.txt
 
 if [ "$1" = 1 ]; then
-    cat /etc/apt/sources.list.d/*.list >> /tmp/batchomatic/reposRaw.txt || true
-    cat /etc/apt/cydiasources.d/*.list >> /tmp/batchomatic/reposRaw.txt || true
+    cat /etc/apt/sources.list.d/*.list >> /tmp/batchomatic/reposRaw.txt || YES
+    cat /etc/apt/cydiasources.d/*.list >> /tmp/batchomatic/reposRaw.txt || YES
 elif [ "$1" = 2 ]; then
-    cat "/var/mobile/Library/Application Support/xyz.willy.Zebra/sources.list" >> /tmp/batchomatic/reposRaw.txt || true
+    cat "/var/mobile/Library/Application Support/xyz.willy.Zebra/sources.list" >> /tmp/batchomatic/reposRaw.txt || YES
     addUtilityRepos
 elif [ "$1" = 3 ]; then
-    cat /etc/apt/sources.list.d/*.sources >> /tmp/batchomatic/reposRaw.txt || true
+    cat /etc/apt/sources.list.d/*.sources >> /tmp/batchomatic/reposRaw.txt || YES
     addUtilityRepos
 elif [ "$1" = 4 ]; then
-    ls "/var/mobile/Library/Application Support/Installer/SourcesFiles" | sed 's:_:/:g' | sed 's:\(.*\)-Packages:\1:' >> /tmp/batchomatic/reposWithSlash.txt || true
+    ls "/var/mobile/Library/Application Support/Installer/SourcesFiles" | sed 's:_:/:g' | sed 's:\(.*\)-Packages:\1:' >> /tmp/batchomatic/reposWithSlash.txt || YES
     addUtilityRepos
 fi
 


### PR DESCRIPTION
Zebra renamed the view controller Batchomatic expects to put the button on (not sure why they renamed it, I will try to get it re-named back…)

Anyway, this PR also does a lot of general code style cleanup:
- Ignores some theos-related folders (`.gitignore`)
- Use `BOOL` instead of `bool`, and `YES`/`NO` instead of `true`/`false`
- Add comment block headers to every source file
- Use the latest SDK in the Makefile
- Removes redundant method declarations in interfaces
- Removes redundant `== true/false` statements
- Makes Batchomatic properties `nonatomic` (you should always do this unless you want `atomic` properties for some reason)
- Curbs excessively long lines to around ~120 characters

Everything still compiles fine. Besides the bugfix and changes to the Makefile, all source changes are purely semantic and couldn't possibly introduce any bugs.

I see that there is another PR about Zebra. I'm not sure what the hold up is there, but if you want I'll wait until that gets merged, then rebase my changes on top of that.